### PR TITLE
extrainfo fix, t&c hit box is bigger

### DIFF
--- a/src/components/ModalPayment/ModalPayment.tsx
+++ b/src/components/ModalPayment/ModalPayment.tsx
@@ -104,7 +104,6 @@ const ModalPayment = ({
             </div>
           </div>
           <CardSection /> <br />
-
           <h3>Checkout details</h3>
           <span>
             {purchaseTypePhrase} of <b>${amount}</b> to Shunfa Bakery

--- a/src/components/ModalPayment/SquareModal.tsx
+++ b/src/components/ModalPayment/SquareModal.tsx
@@ -67,11 +67,11 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
           const newErrors =
             errorMessages.length > 0
               ? [
-                  ...errorMessages,
-                  responseErrors.map(
-                    (error: { detail: string }) => error.detail
-                  ),
-                ]
+                ...errorMessages,
+                responseErrors.map(
+                  (error: { detail: string }) => error.detail
+                ),
+              ]
               : responseErrors.map((error: { detail: string }) => error.detail);
           setErrorsMessages(newErrors);
         }
@@ -140,7 +140,7 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
           </span>
           <p />
           <div>
-            <label className={styles.tc}>
+            <label className={styles.termsAndConditions}>
               <input
                 type="checkbox"
                 id="checkbox"
@@ -161,14 +161,14 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
               exchanged for this donation.
             </p>
           ) : (
-            <p>
-              By proceeding with your purchase, you understand that the gift
+              <p>
+                By proceeding with your purchase, you understand that the gift
               card is not redeemable for cash and can only be used at{' '}
-              {sellerName}. All purchases are final. In the event that the
+                {sellerName}. All purchases are final. In the event that the
               merchant is no longer open at the time of redemption, Send
               Chinatown Love Inc. will not be able to refund your purchase.
-            </p>
-          )}
+              </p>
+            )}
           <div className={styles.btnRow}>
             <button
               type="button"

--- a/src/components/ModalPayment/SquareModal.tsx
+++ b/src/components/ModalPayment/SquareModal.tsx
@@ -67,11 +67,11 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
           const newErrors =
             errorMessages.length > 0
               ? [
-                ...errorMessages,
-                responseErrors.map(
-                  (error: { detail: string }) => error.detail
-                ),
-              ]
+                  ...errorMessages,
+                  responseErrors.map(
+                    (error: { detail: string }) => error.detail
+                  ),
+                ]
               : responseErrors.map((error: { detail: string }) => error.detail);
           setErrorsMessages(newErrors);
         }
@@ -139,16 +139,19 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
             {purchaseTypePhrase} of <b>${amount}</b> to {sellerName}{' '}
           </span>
           <p />
-          <div className={styles.row}>
-            <input
-              type="checkbox"
-              name="checkbox"
-              className={styles.checkbox}
-              value="Agree"
-              onClick={checkAgreement}
-            />
-            <label htmlFor="checkbox">
-              I agree with the <b>Terms & Conditions</b>
+          <div>
+            <label className={styles.tc}>
+              <input
+                type="checkbox"
+                id="checkbox"
+                name="checkbox"
+                className={styles.checkbox}
+                value="Agree"
+                onClick={checkAgreement}
+              />
+              <span>
+                I agree with the <b>Terms & Conditions</b>
+              </span>
             </label>
           </div>
           {purchaseTypePhrase === 'Donation' ? (
@@ -158,14 +161,14 @@ const ModalPayment = ({ purchaseType, sellerId, sellerName }: Props) => {
               exchanged for this donation.
             </p>
           ) : (
-              <p>
-                By proceeding with your purchase, you understand that the gift
+            <p>
+              By proceeding with your purchase, you understand that the gift
               card is not redeemable for cash and can only be used at{' '}
-                {sellerName}. All purchases are final. In the event that the
+              {sellerName}. All purchases are final. In the event that the
               merchant is no longer open at the time of redemption, Send
               Chinatown Love Inc. will not be able to refund your purchase.
-              </p>
-            )}
+            </p>
+          )}
           <div className={styles.btnRow}>
             <button
               type="button"

--- a/src/components/ModalPayment/styles.module.scss
+++ b/src/components/ModalPayment/styles.module.scss
@@ -14,7 +14,7 @@
 
 .row,
 .inputRow,
-.tc {
+.termsAndConditions {
   display: flex;
   flex-direction: row;
   width: 100%;
@@ -22,7 +22,7 @@
   margin-bottom: 10px;
 }
 
-.tc:hover {
+.termsAndConditions:hover {
   text-decoration: underline;
 }
 

--- a/src/components/ModalPayment/styles.module.scss
+++ b/src/components/ModalPayment/styles.module.scss
@@ -13,12 +13,17 @@
 }
 
 .row,
-.inputRow {
+.inputRow,
+.tc {
   display: flex;
   flex-direction: row;
   width: 100%;
   align-items: center;
   margin-bottom: 10px;
+}
+
+.tc:hover {
+  text-decoration: underline;
 }
 
 .checkbox {

--- a/src/components/OwnerPanel/OwnerPanel.tsx
+++ b/src/components/OwnerPanel/OwnerPanel.tsx
@@ -17,7 +17,7 @@ interface Props {
   sellerId: string;
   sellerName: string;
   progressBarColor: string;
-  extraInfo: { [prop: string]: any }
+  extraInfo: { [prop: string]: any };
 }
 
 interface State {
@@ -41,12 +41,20 @@ const OwnerPanel = (props: Props) => {
     return 100;
   };
 
+  const validExtraInfo = Object.keys(props.extraInfo).filter((current) => {
+    return props.extraInfo[current] != null;
+  });
+
   return (
     <section className={classnames(styles.container, props.className)}>
       <figure className={styles.ownerContainer}>
         <img
           className={styles.ownerImage}
-          src={props.imageSrc ? process.env.REACT_APP_BASE_URL + props.imageSrc : defaultOwnerImage}
+          src={
+            props.imageSrc
+              ? process.env.REACT_APP_BASE_URL + props.imageSrc
+              : defaultOwnerImage
+          }
           alt={props.ownerName}
         />
       </figure>
@@ -97,44 +105,45 @@ const OwnerPanel = (props: Props) => {
           </button>
         )}
       </div>
-      {Object.keys(props.extraInfo).length !== 0 ?
-        <div className = {styles.extraInfoContainer}>
-          {Object.keys(props.extraInfo).map((current) => {
+      {validExtraInfo !== [] ? (
+        <div className={styles.extraInfoContainer}>
+          {validExtraInfo.map((current) => {
             if (current === 'Website' || current === 'Menu') {
               return (
                 <>
-                  <p className={styles.extraInfoKey}>
+                  <p key={current} className={styles.extraInfoKey}>
                     {`${current}: `}
-                    <a className={styles.extraInfoValue} href={`http://${props.extraInfo[current]}`}>{props.extraInfo[current]}</a>
+                    <a
+                      className={styles.extraInfoValue}
+                      href={`http://${props.extraInfo[current]}`}
+                    >
+                      {props.extraInfo[current]}
+                    </a>
                   </p>
                 </>
-              )
-            }
-            else {
+              );
+            } else
               return (
                 <>
-                  <p className={styles.extraInfoKey}>
+                  <p key={current} className={styles.extraInfoKey}>
                     {`${current}: `}
                     <span className={styles.extraInfoValue}>
                       {props.extraInfo[current]}
                     </span>
                   </p>
                 </>
-              )
-            }
+              );
           })}
-        </div >
-        :
+        </div>
+      ) : (
         ''
-      }
-
+      )}
 
       <ModalBox
         purchaseType={purchaseType}
         sellerId={props.sellerId}
         sellerName={props.sellerName}
       />
-
 
       {/* hide extra info section until needed */}
       {/* <div className={styles.summaryContainer}>
@@ -173,7 +182,6 @@ const OwnerPanel = (props: Props) => {
         {/* https://www.npmjs.com/package/google-map-react */}
       </div>
     </section>
-
   );
 };
 

--- a/src/components/OwnerPanel/styles.module.scss
+++ b/src/components/OwnerPanel/styles.module.scss
@@ -103,18 +103,15 @@ p {
 }
 
 .extraInfoKey {
-  font-weight: bold
+  font-weight: bold;
 }
 
 .extraInfoValue {
-  font-weight:normal
+  font-weight: normal;
 }
 
 .extraInfoContainer {
   width: 100%;
-  border-top: '1px solid #dedede';
-  border-bottom: '1px solid #dedede';
+  border-top: 1px solid #dedede;
+  border-bottom: 1px solid #dedede;
 }
-
-
-

--- a/src/components/SellerPage/SellerPage.tsx
+++ b/src/components/SellerPage/SellerPage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import HeroBanner from '../HeroBanner';
 import Footer from '../Footer';
-import { sampleMerchant } from './sample-merchant';
 import { StoreInfo } from '../StoreInfo';
 import OwnerPanel from '../OwnerPanel';
 import { ModalPaymentProvider } from '../../utilities/hooks/ModalPaymentContext/context';
@@ -52,12 +51,12 @@ const SellerPage: React.FC<{}> = () => {
               sellerName={seller.name}
               progressBarColor={seller.progress_bar_color}
               extraInfo={{
-              Type: seller.business_type,
-              Employees: seller.num_employees,
-              Founded: seller.founded_year,
-              Website: seller.website_url,
-              Menu: seller.menu_url
-            }}
+                Type: seller.business_type,
+                Employees: seller.num_employees,
+                Founded: seller.founded_year,
+                Website: seller.website_url,
+                Menu: seller.menu_url,
+              }}
               // TODO(jtmckibb): Should not crash here
               sellerId={id!}
             />

--- a/src/components/StoreInfo/StoreInfo.tsx
+++ b/src/components/StoreInfo/StoreInfo.tsx
@@ -13,10 +13,13 @@ export const StoreInfo: React.SFC<Props> = ({ seller }) => {
   const { summary, story, cuisineName, locations } = seller;
   return (
     <section className={classnames(styles.container)}>
-
       {
         <img
-          src={seller.hero_image_url ? process.env.REACT_APP_BASE_URL + seller.hero_image_url : defaultStoreFront}
+          src={
+            seller.hero_image_url
+              ? process.env.REACT_APP_BASE_URL + seller.hero_image_url
+              : defaultStoreFront
+          }
           alt={`${seller.name} Illustration`}
           className={styles.merchantIllustration}
         />


### PR DESCRIPTION
extra info section hides null. Also picked up the t&c hitbox minor fix, hovering underlines the text and you can click anywhere in the container. open to suggestions on anything better!
<img width="322" alt="Screen Shot 2020-04-23 at 1 01 20 PM" src="https://user-images.githubusercontent.com/47200207/80144385-6418b080-857c-11ea-93b2-64151f003ffb.png">
