### PR TITLE
Disable button to prevent duplicate donations/purchages

### DIFF
--- a/src/components/ModalPayment/SquareModal.tsx
+++ b/src/components/ModalPayment/SquareModal.tsx
@@ -180,6 +180,7 @@ const ModalPayment = ({
                 value="checkedA"
                 inputProps={{ 'aria-label': 'Checkbox A' }}
                 onClick={checkAgreement}
+                checked={isChecked}
               />
               <span>
                 I agree with the <b>Terms & Conditions</b>
@@ -209,7 +210,7 @@ const ModalPayment = ({
             >
               ᐸ Back
             </button>
-            <SubmissionButton canSubmit={canSubmit} />
+            <SubmissionButton canSubmit={canSubmit} setChecked={setChecked} />
           </div>
         </SquarePaymentForm>
       </div>

--- a/src/components/ModalPayment/SubmissionButton.tsx
+++ b/src/components/ModalPayment/SubmissionButton.tsx
@@ -1,24 +1,31 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { Context } from 'react-square-payment-form';
 
 type Props = {
   canSubmit: boolean;
+  setChecked: (isChecked: boolean) => void;
 };
 
-const SubmissionButton = ({ canSubmit }: Props) => {
+const SubmissionButton = ({ canSubmit, setChecked }: Props) => {
   const context = useContext(Context);
+  var [submittable] = useState(false);
 
   const handleSubmit = (evt: { preventDefault: () => void }) => {
     evt.preventDefault();
     context.onCreateNonce();
   };
 
+  submittable = canSubmit;
+
   return (
     <button
       type="button"
       className={'modalButton--filled'}
-      onClick={handleSubmit}
-      disabled={canSubmit === false}
+      onClick={(e) => {
+        handleSubmit(e);
+        setChecked(false);
+      }}
+      disabled={!submittable}
     >
       Confirm
     </button>


### PR DESCRIPTION
Demo: https://drive.google.com/open?id=1m51ZlR56oLG4DVIsVw8YMa9r6LXxVKrJ

Disables the button right after hitting submit. The button can be re-enabled by clicking on any input field.
