### PR TITLE
Pass idempotency_key in charges POST request

### DIFF
--- a/src/utilities/api/interactionManager.ts
+++ b/src/utilities/api/interactionManager.ts
@@ -78,6 +78,7 @@ export const makeSquarePayment = async (
   buyer: Buyer
 ) => {
   const { email, name } = buyer;
+  const idempotencyKey = buyer.idempotency_key;
 
   return await axios
     .post(
@@ -89,6 +90,7 @@ export const makeSquarePayment = async (
         email,
         name,
         seller_id: sellerId,
+        idempotency_key: idempotencyKey,
       },
       { headers: { 'Access-Control-Allow-Origin': '*' } }
     )


### PR DESCRIPTION
Pass idempotency_key to the server so it can be used to dedup charges
 
Testing plan:
Verified  `idempotency_key` is set in the HTTP params
```
request: {http_method: "POST", query_url: "https://connect.squareupsandbox.com/v2/payments",…}
headers: {accept: "application/json", content-type: "application/json; charset=utf-8",…}
http_method: "POST"
parameters: "{"source_id":"cnon:CBASEBoAZRQl0jCLqDiBEDLaDQ0","idempotency_key":"49621545-c41f-4770-98c6-c12d4c21c4f7","amount_money":{"amount":1000,"currency":"USD"},"buyer_email_address":"danthaman44@gmail.com","note":"Thank you for supporting Shunfa Bakery.","location_id":"E4R1NCMHG7B2Y"}"
query_url: "https://connect.squareupsandbox.com/v2/payments"
```

Verified  `idempotency_key` is received by the Rails ChargesController
```
Started POST "/charges" for 127.0.0.1 at 2020-05-01 00:10:34 -0400
Processing by ChargesController#create as HTML
  Parameters: {"is_square"=>true, "nonce"=>"cnon:CBASEBoAZRQl0jCLqDiBEDLaDQ0", "line_items"=>[{"amount"=>1000, "currency"=>"usd", "item_type"=>"donation", "quantity"=>1}], "email"=>"danthaman44@gmail.com", "name"=>"Wei", "seller_id"=>"shunfa-bakery", "idempotency_key"=>"83e8a3e6-d791-4111-b389-ba074da2a01e", "charge"=>{"is_square"=>true, "nonce"=>"cnon:CBASEBoAZRQl0jCLqDiBEDLaDQ0", "line_items"=>[{"amount"=>1000, "currency"=>"usd", "item_type"=>"donation", "quantity"=>1}], "email"=>"danthaman44@gmail.com", "name"=>"Wei", "seller_id"=>"shunfa-bakery", "idempotency_key"=>"83e8a3e6-d791-4111-b389-ba074da2a01e"}}
```