### PR TITLE
Updated seller modal hover states

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -53,6 +53,12 @@ h3 {
   &--filled {
     @include base-button;
     color: white;
+    background-color: $default-button-color;
+    border-color: $default-button-color;
+  }
+
+  &--filled:hover {
+    @include base-button;
     background-color: $standard-red;
     border-color: $standard-red;
   }
@@ -61,6 +67,13 @@ h3 {
     @include base-button;
     color: $default-button-color;
     background-color: white;
+  }
+
+  &--outlined:hover {
+    @include base-button;
+    color: $default-button-color;
+    background-color: $standard-red;
+    border-color: $default-button-color;
   }
 }
 


### PR DESCRIPTION
Talked to Nanxi offline, the red is only supposed to be a hover state for the buttons. 
Reverted the base color to black/white and implemented the hover state.
![modal-hover](https://user-images.githubusercontent.com/2313868/81243969-2b96bf00-8fdf-11ea-95c8-6d6af4153209.gif)
