### PR TITLE
Quickfix for numsupporters tooltip on merchants page

### DIFF
--- a/src/components/OwnerPanel/styles.module.scss
+++ b/src/components/OwnerPanel/styles.module.scss
@@ -112,7 +112,3 @@ p {
   border-top: 1px solid #dedede;
   border-bottom: 1px solid #dedede;
 }
-
-table {
-  width: 100%;
-}

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -63,7 +63,7 @@ const ProgressBar = ({
           <SupporterTooltip
             title={
               <React.Fragment>
-                <table>
+                <table className={styles.tooltipTable}>
                   <tbody>
                     <tr>
                       <td>

--- a/src/components/ProgressBar/styles.module.scss
+++ b/src/components/ProgressBar/styles.module.scss
@@ -20,6 +20,7 @@
   justify-content: space-between;
 }
 
-table {
+.tooltipTable {
   width: 100%;
 }
+

--- a/src/components/ProgressBar/styles.module.scss
+++ b/src/components/ProgressBar/styles.module.scss
@@ -19,3 +19,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+table {
+  width: 100%;
+}


### PR DESCRIPTION
Left a table style in the wrong .scss file, tooltip is misaligned in merchants directory page


