### PR TITLE
Prefill  donation amt to reduce friction

### DIFF
--- a/src/components/ModalAmount/ModalAmount.tsx
+++ b/src/components/ModalAmount/ModalAmount.tsx
@@ -20,7 +20,7 @@ export const Modal = (props: Props) => {
   const { t } = useTranslation();
 
   const { amount } = useModalPaymentState();
-  const [isCustomAmount, setIsCustomAmount] = useState(false);
+  const [isCustomAmount, setIsCustomAmount] = useState(true);
   const [selected, setSelected] = useState('');
   const dispatch = useModalPaymentDispatch();
   const minAmount = 5;

--- a/src/components/OwnerPanel/OwnerPanel.tsx
+++ b/src/components/OwnerPanel/OwnerPanel.tsx
@@ -156,8 +156,8 @@ const OwnerPanel = ({ seller }: Props) => {
           })}
         </div>
       ) : (
-          ''
-        )}
+        ''
+      )}
 
       <ModalBox
         purchaseType={purchaseType}

--- a/src/utilities/hooks/ModalPaymentContext/reducers.ts
+++ b/src/utilities/hooks/ModalPaymentContext/reducers.ts
@@ -32,7 +32,12 @@ const ModalPaymentReducer = (state: ModalPaymentState, action: Action) => {
         },
       };
     case CLOSE_MODAL:
-      return { ...state, modalView: -1, customInput: false, amount: '' };
+      return {
+        ...state,
+        modalView: -1,
+        customInput: false,
+        amount: defaultState.amount,
+      };
     case CLEAR_FORMS:
       return defaultState;
     default:

--- a/src/utilities/hooks/ModalPaymentContext/types.ts
+++ b/src/utilities/hooks/ModalPaymentContext/types.ts
@@ -19,7 +19,7 @@ export type ModalPaymentState = {
 };
 
 export const defaultState: ModalPaymentState = {
-  amount: '',
+  amount: '5',
   customInput: false,
   modalView: -1,
   sellerData: {


### PR DESCRIPTION
$5 is our second most common donation amount. Since we don't have a menu option for $5, lets prefill it into the input form to reduce friction for people who want to make small donations

<img width="642" alt="Screen Shot 2020-05-24 at 11 25 11 PM" src="https://user-images.githubusercontent.com/2313868/82775557-0b0b9900-9e16-11ea-90bf-d76ecf9bec45.png">
<img width="917" alt="Screen Shot 2020-05-24 at 11 28 19 PM" src="https://user-images.githubusercontent.com/2313868/82775631-46a66300-9e16-11ea-9826-18d4e0666a5c.png">


