### PR TITLE
Added Facebook tracking for user interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12734,6 +12734,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-facebook-pixel": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/react-facebook-pixel/-/react-facebook-pixel-0.1.3.tgz",
+      "integrity": "sha512-9Zlnmjn2zGPGucuaxjHkNHW3DvDMCLkM9DFx0o0j7u3fzzsD+2bOtG1JA3PP8A11U5WBwoL0BD/RGQmaDvaIDw=="
+    },
     "react-ga": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-clipboard-icon": "^1.1.0",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "^16.13.1",
+    "react-facebook-pixel": "^0.1.3",
     "react-ga": "^2.7.0",
     "react-i18next": "^11.4.0",
     "react-number-format": "^4.4.1",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -6,6 +6,7 @@ import Loader from '../Loader';
 import Header from '../Navbar';
 import Footer from '../Footer';
 import { ModalPaymentProvider } from '../../utilities/hooks/ModalPaymentContext/context';
+import ReactPixel from 'react-facebook-pixel';
 
 const trackingId = process.env.REACT_APP_API_ENDPOINT!;
 // For Testing purposes: https://github.com/react-ga/react-ga/issues/322
@@ -28,6 +29,13 @@ history.listen((location) => {
 const SellerPage = lazy(() => import('../SellerPage'));
 const MerchantsPage = lazy(() => import('../MerchantsPage'));
 const ErrorPage = lazy(() => import('../404Page'));
+
+const options = {
+  autoConfig: true, // set pixel's autoConfig
+  debug: true, // enable logs
+};
+const pixelId = process.env.REACT_APP_FB_PIXEL_ID!;
+ReactPixel.init(pixelId, undefined, options);
 
 const App = () => {
   const [menuOpen, setMenuOpen] = useState(false);

--- a/src/components/MerchantsPage/DonationPool.tsx
+++ b/src/components/MerchantsPage/DonationPool.tsx
@@ -9,12 +9,14 @@ import {
 } from '../../utilities/general/responsive';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import ReactPixel from 'react-facebook-pixel';
 
 const DonationPoolBox = () => {
   const { t } = useTranslation();
   const dispatch = useModalPaymentDispatch();
 
   const openModal = (e: any) => {
+    ReactPixel.trackCustom('DonationPoolButtonClick', {});
     e.preventDefault();
     dispatch({ type: SET_MODAL_VIEW, payload: 0 });
   };

--- a/src/components/MerchantsPage/MerchantsPage.tsx
+++ b/src/components/MerchantsPage/MerchantsPage.tsx
@@ -10,11 +10,13 @@ import nycMapBackground from './images/nyc_3.png';
 import { LoaderFillerContainer } from '../Loader';
 import DonationPoolBox from './DonationPool';
 import { useTranslation } from 'react-i18next';
+import ReactPixel from 'react-facebook-pixel';
 
 interface Props {
   menuOpen: boolean;
 }
 
+ReactPixel.trackCustom('MerchantsPageView', {});
 const MerchantsPage = (props: Props) => {
   const { t } = useTranslation();
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utilities/hooks/ModalPaymentContext/constants';
 import { getSeller } from '../../utilities';
 import styled from 'styled-components';
+import ReactPixel from 'react-facebook-pixel';
 
 export interface Props {
   purchaseType: string;
@@ -32,6 +33,7 @@ export const Modal = (props: Props) => {
   const dispatch = useModalPaymentDispatch();
 
   const closeModal = async (e: any) => {
+    ReactPixel.trackCustom('ModalCloseButtonClick', {});
     e.preventDefault();
     if (modalView === 2) {
       const { data } = props.sellerId && (await getSeller(props.sellerId));

--- a/src/components/ModalAmount/ModalAmount.tsx
+++ b/src/components/ModalAmount/ModalAmount.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../utilities/hooks/ModalPaymentContext/constants';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
+import ReactPixel from 'react-facebook-pixel';
 
 export interface Props {
   purchaseType: string;
@@ -33,6 +34,7 @@ export const Modal = (props: Props) => {
   };
 
   const openModal = (e: any) => {
+    ReactPixel.trackCustom('PaymentNextButtonClick', { amount: amount });
     e.preventDefault();
     dispatch({ type: SET_MODAL_VIEW, payload: 1 });
   };

--- a/src/components/ModalBuyMeal/ModalBuyMeal.tsx
+++ b/src/components/ModalBuyMeal/ModalBuyMeal.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import walletImage from './wallet.png';
 import cardImage from './card.png';
+import ReactPixel from 'react-facebook-pixel';
 
 export interface Props {
   purchaseType: string;
@@ -30,6 +31,9 @@ export const Modal = (props: Props) => {
   };
 
   const openModal = (e: any) => {
+    ReactPixel.trackCustom('GiftMealPaymentNextButtonClick', {
+      numberOfMeals: numberOfMeals,
+    });
     e.preventDefault();
     dispatch({ type: SET_MODAL_VIEW, payload: 1 });
   };

--- a/src/components/ModalPayment/SubmissionButton.tsx
+++ b/src/components/ModalPayment/SubmissionButton.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import { Context } from 'react-square-payment-form';
+import ReactPixel from 'react-facebook-pixel';
 
 type Props = {
   canSubmit: boolean;
@@ -10,6 +11,7 @@ const SubmissionButton = ({ canSubmit }: Props) => {
   var [submittable] = useState(false);
 
   const handleSubmit = (evt: { preventDefault: () => void }) => {
+    ReactPixel.trackCustom('PaymentConfirmButtonClick', {});
     evt.preventDefault();
     context.onCreateNonce();
   };

--- a/src/components/OwnerPanel/OwnerPanel.tsx
+++ b/src/components/OwnerPanel/OwnerPanel.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-share';
 import styled from 'styled-components';
 import styles from './styles.module.scss';
+import ReactPixel from 'react-facebook-pixel';
 
 interface Props {
   seller: BrowsePageSeller;
@@ -35,6 +36,21 @@ const OwnerPanel = ({ seller }: Props) => {
   const showModal = (event: any) => {
     dispatch({ type: SET_MODAL_VIEW, payload: 0 });
     setPurchaseType(event.target.value);
+  };
+
+  const donationClickHander = (event: any) => {
+    ReactPixel.trackCustom('DonationButtonClick', {});
+    showModal(event);
+  };
+
+  const voucherClickHander = (event: any) => {
+    ReactPixel.trackCustom('VoucherButtonClick', {});
+    showModal(event);
+  };
+
+  const giftMealClickHander = (event: any) => {
+    ReactPixel.trackCustom('GiftMealButtonClick', {});
+    showModal(event);
   };
 
   const extraInfo = {
@@ -99,7 +115,7 @@ const OwnerPanel = ({ seller }: Props) => {
           <button
             value="donation"
             className={classnames(styles.button, 'button--filled')}
-            onClick={showModal}
+            onClick={donationClickHander}
           >
             Donation
           </button>
@@ -108,7 +124,7 @@ const OwnerPanel = ({ seller }: Props) => {
           <button
             value="gift_card"
             className={classnames(styles.button, 'button--outlined')}
-            onClick={showModal}
+            onClick={voucherClickHander}
           >
             Voucher
           </button>
@@ -117,7 +133,7 @@ const OwnerPanel = ({ seller }: Props) => {
           <button
             value="buy_meal"
             className={classnames(styles.button, 'button--redfilled')}
-            onClick={showModal}
+            onClick={giftMealClickHander}
           >
             Gift a meal
           </button>

--- a/src/components/SellerPage/SellerPage.tsx
+++ b/src/components/SellerPage/SellerPage.tsx
@@ -12,11 +12,13 @@ import { getSeller } from '../../utilities';
 import { useParams } from 'react-router-dom';
 import Loader from '../Loader';
 import styled from 'styled-components';
+import ReactPixel from 'react-facebook-pixel';
 
 interface Props {
   menuOpen: boolean;
 }
 
+ReactPixel.trackCustom('SellerPageView', {});
 const SellerPage = (props: Props) => {
   // fix typing
   const [loading, setLoading] = useState<boolean>(false);


### PR DESCRIPTION
Test plan:
-Verified tracking events are being sent via FB Pixel Helper Chrome extension
-Verified tracking events show up in Ads Manager
<img width="536" alt="Screen Shot 2020-05-28 at 10 40 24 PM" src="https://user-images.githubusercontent.com/2313868/83216138-8cc13680-a136-11ea-8f83-76f79d054c96.png">
<img width="1858" alt="Screen Shot 2020-05-28 at 10 09 29 PM" src="https://user-images.githubusercontent.com/2313868/83216145-9185ea80-a136-11ea-8898-918a5e0a855f.png">
