### PR TITLE
css adjustments

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -81,6 +81,7 @@ const ModalContainer = styled.div`
   max-height: 85vh;
   width: 725px;
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+  height: 65%;
 
   @media only screen and (max-width: 799px) {
     width: 85%;

--- a/src/components/ModalAmount/ModalAmount.tsx
+++ b/src/components/ModalAmount/ModalAmount.tsx
@@ -206,6 +206,6 @@ const NextButton = styled.button`
 
 const Header = styled.div`
   font-family: 'Open Sans', sans-serif;
-  font-size: 32px;
+  font-size: 30px;
   font-weight: 600;
 `;


### PR DESCRIPTION
reduced font-size on the header so that restaurant name fits on one line, and set the default value of height to 65% to prevent scrolling on screens that can fit the modal
<img width="829" alt="Screen Shot 2020-05-29 at 2 35 28 AM" src="https://user-images.githubusercontent.com/34514252/83229135-72e31c00-a155-11ea-9090-b9e24b15703d.png">
