### PR TITLE
Fixes owner panel button overflow on really small screens

### DIFF
--- a/src/components/OwnerPanel/styles.module.scss
+++ b/src/components/OwnerPanel/styles.module.scss
@@ -45,6 +45,7 @@ $container-size: 160px;
 
   @include for-phone-only {
     row-gap: 27px;
+    column-gap: 12px;
   }
 }
 
@@ -54,16 +55,22 @@ $container-size: 160px;
   font-size: 16px;
   letter-spacing: 0.05em;
   cursor: pointer;
-  min-width: auto;
-  white-space: nowrap;
 
   &.moreThanTwoButtons,
   &:only-child {
     grid-column: 1 / span 2;
   }
 
+  &,
+  &:active,
+  &:hover {
+    min-width: auto;
+  }
+
   @include for-phone-only {
     font-size: 16px;
+    padding-left: 10px;
+    padding-right: 10px;
   }
 }
 

--- a/src/components/OwnerPanel/styles.module.scss
+++ b/src/components/OwnerPanel/styles.module.scss
@@ -55,6 +55,9 @@ $container-size: 160px;
   font-size: 16px;
   letter-spacing: 0.05em;
   cursor: pointer;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
   &.moreThanTwoButtons,
   &:only-child {
@@ -65,12 +68,12 @@ $container-size: 160px;
   &:active,
   &:hover {
     min-width: auto;
+    padding-left: 10px;
+    padding-right: 10px;
   }
 
   @include for-phone-only {
     font-size: 16px;
-    padding-left: 10px;
-    padding-right: 10px;
   }
 }
 


### PR DESCRIPTION
Adds ellipsis to overflowing button text on small screen sizes

iPhone SE:
![image](https://user-images.githubusercontent.com/19297741/83360043-4f35f680-a34c-11ea-858e-d9e574a02d5b.png)

Bigger mobile sizes like iPhone 8:
![image](https://user-images.githubusercontent.com/19297741/83360101-b05dca00-a34c-11ea-97b3-ac789cd88965.png)
