### PR TITLE
Fixing a tiny typo in the Chinese text for donation pool

### DIFF
--- a/src/locales/cn/translation.json
+++ b/src/locales/cn/translation.json
@@ -55,7 +55,7 @@
     "salon": "美发店"
   },
   "donationPool": {
-    "header": "如果你不太缺点捐款给那个商家？",
+    "header": "如果你不太确定捐款给哪个商家？",
     "description1": "我们会把你的捐款平均分配给商家",
     "description2": "",
     "button": "请支持中国城!"


### PR DESCRIPTION
[Trello card](https://trello.com/c/TsaP1d6C/485-there-are-some-mistakes-on-our-merchants-page-the-following-sentences-should-be-%E5%A6%82%E6%9E%9C%E4%BD%A0%E4%B8%8D%E5%A4%AA%E7%A1%AE%E5%AE%9A%E6%8D%90%E6%AC%BE%E7%BB%99%E5%93%AA%E4%B8%AA%E5%95%86%E5%AE%B6%EF%BC%9F)