### PR TITLE
Single Use Voucher Redemptions and Overall Redemption Flow Tweaks

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -84,7 +84,7 @@ const App = () => {
           </Route>
           <Route path="/merchants">{returnComponent('merchants')}</Route>
           <Route path="/:id">{returnComponent('seller')}</Route>
-          <Route path="/:id#story">{returnComponent('seller')}</Route> */}
+          <Route path="/:id#story">{returnComponent('seller')}</Route>
           <Route>{returnComponent('error')}</Route>
         </Switch>
       </Suspense>

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -3,7 +3,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import styled from 'styled-components';
 
 type Props = {
-  isPage?: Boolean;
+  isPage?: boolean;
 };
 
 const Loader: React.SFC<Props> = ({ isPage }: Props) => {

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const ContributionBar = ({ totalDonations, totalGiftCards }: Props) => {
   const { t } = useTranslation();
-  
+
   const progressWidth = (raised: number, total: number) => {
     if (raised < total) return (raised / total) * 100;
     return 100;
@@ -36,9 +36,7 @@ const ContributionBar = ({ totalDonations, totalGiftCards }: Props) => {
           <b>${(Math.floor(totalDonations) / 100).toLocaleString()}</b>
         </span>
       </TextContainer>
-      <p>
-        {t('contributionBar.footer')}
-      </p>
+      <p>{t('contributionBar.footer')}</p>
     </Container>
   );
 };

--- a/src/components/MerchantsPage/MerchantNavBar.tsx
+++ b/src/components/MerchantsPage/MerchantNavBar.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const NavBar = ({ filterStoreType }: Props) => {
   const { t } = useTranslation();
-  
+
   const [selected, setSelected] = useState('all');
 
   const setStoreType = (type: any, e: any) => {

--- a/src/components/OwnerPanel/OwnerPanel.tsx
+++ b/src/components/OwnerPanel/OwnerPanel.tsx
@@ -153,7 +153,7 @@ const OwnerPanel = ({ seller }: Props) => {
               return (
                 <React.Fragment key={current}>
                   <p key={current} className={styles.extraInfoKey}>
-                    {`${t('ownerPanel.extraInfo.'+ current)}: `}
+                    {`${t('ownerPanel.extraInfo.' + current)}: `}
                     <a
                       className={styles.extraInfoValue}
                       href={`http://${extraInfo[current]}`}
@@ -169,7 +169,7 @@ const OwnerPanel = ({ seller }: Props) => {
               return (
                 <React.Fragment key={current}>
                   <p key={current} className={styles.extraInfoKey}>
-                    {`${t('ownerPanel.extraInfo.'+ current)}: `}
+                    {`${t('ownerPanel.extraInfo.' + current)}: `}
                     <span className={styles.extraInfoValue}>
                       {extraInfo[current]}
                     </span>

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../utilities/hooks/VoucherContext/constants';
 import {
   AmountContainer,
-  MessageConatiner,
+  MessageContainer,
   Text,
   Footer,
   NextButton,
@@ -81,7 +81,7 @@ const Amount = (props: Props) => {
           max="10000"
         />
       </AmountContainer>
-      <MessageConatiner>
+      <MessageContainer>
         <Text size="16px" color="#DD678A" width="50%">
           {error}
         </Text>
@@ -93,7 +93,7 @@ const Amount = (props: Props) => {
             Remaining
           </Text>
         </Text>
-      </MessageConatiner>
+      </MessageContainer>
       <Footer>
         <Voucher>
           Voucher Code: <Bold>{voucher.seller_gift_card_id}</Bold>{' '}

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -18,6 +18,7 @@ import {
   NextButton,
   Voucher,
   Bold,
+  FlexFillSpace,
 } from './styles';
 
 interface Props {}
@@ -75,30 +76,33 @@ const Amount = (props: Props) => {
           Current balance <MoreInfo showShadow={true} inverted={true} />
         </CurrentBalanceRow>
       </AmountContainer>
-      <AmountContainer>
-        <Text size="18px">How much are you spending today?</Text>
-        <InputWrapper>
-          <AmountInput
-            onChange={handleAmount}
-            placeholder={'0.00'}
-            type="number"
-            error={!!error}
-          />
-        </InputWrapper>
-      </AmountContainer>
-      <MessageContainer>
-        <Text size="16px" color="#DD678A" width="50%">
-          {error}
-        </Text>
-        <Text size="16px" width="50%">
-          <Text color="black" width="100%" align="flex-end" padding="true">
-            $ {(voucher.amount / 100 - amount).toFixed(2)}
+      <InputAreaWrapper>
+        <AmountContainer>
+          <Text size="18px">How much are you spending today?</Text>
+          <InputWrapper>
+            <AmountInput
+              onChange={handleAmount}
+              placeholder={'0.00'}
+              type="number"
+              error={!!error}
+            />
+          </InputWrapper>
+        </AmountContainer>
+        <MessageContainer>
+          <Text size="16px" color="#DD678A" width="50%">
+            {error}
           </Text>
-          <Text align="flex-end" width="80px">
-            Remaining
+          <Text size="16px" width="50%">
+            <Text color="black" width="100%" align="flex-end" padding="true">
+              $ {(voucher.amount / 100 - amount).toFixed(2)}
+            </Text>
+            <Text align="flex-end" width="80px">
+              Remaining
+            </Text>
           </Text>
-        </Text>
-      </MessageContainer>
+        </MessageContainer>
+      </InputAreaWrapper>
+      <FlexFillSpace></FlexFillSpace>
       <Footer>
         <Voucher>
           Voucher Code: <Bold>{voucher.seller_gift_card_id}</Bold>{' '}
@@ -119,6 +123,7 @@ const Container = styled.div`
   color: black;
   display: flex;
   flex-direction: column;
+  flex: 1;
 `;
 const CurrentBalanceRow = styled(Text)`
   justify-content: center;
@@ -145,4 +150,10 @@ const AmountInput = styled.input`
   border: 1px solid
     ${(props: InputProps) => (props.error ? '#DD678A' : 'black')};
   border-radius: 5px;
+`;
+const InputAreaWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -68,7 +68,7 @@ const Amount = (props: Props) => {
           ${voucher.amount === 0 ? '0.00' : (voucher.amount / 100).toFixed(2)}
         </Text>
         <CurrentBalanceRow size="16px">
-          Current balance <MoreInfo showShadow={true} />
+          Current balance <MoreInfo showShadow={true} inverted={true} />
         </CurrentBalanceRow>
       </AmountContainer>
       <AmountContainer>

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -23,16 +23,16 @@ import {
 
 interface Props {}
 interface TextProps {
-  bold?: String;
-  color?: String;
-  size?: String;
-  width?: String;
-  align?: String;
-  padding?: String;
+  bold?: string;
+  color?: string;
+  size?: string;
+  width?: string;
+  align?: string;
+  padding?: string;
 }
 
 interface InputProps {
-  error?: Boolean;
+  error?: boolean;
 }
 
 const Amount = (props: Props) => {

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -30,6 +30,10 @@ interface TextProps {
   padding?: String;
 }
 
+interface InputProps {
+  error?: Boolean;
+}
+
 const Amount = (props: Props) => {
   const { amount, voucher } = useVoucherState();
   const dispatch = useVoucherDispatch();
@@ -38,7 +42,7 @@ const Amount = (props: Props) => {
 
   const handleAmount = (e) => {
     setError('');
-    if (e.target.value * 100 > voucher.amount)
+    if (e.target.value * 100 > voucher.amount || e.target.value * 100 < 5)
       return setError('Please enter a valid amount');
     dispatch({ type: SET_AMOUNT, payload: e.target.value });
   };
@@ -73,13 +77,14 @@ const Amount = (props: Props) => {
       </AmountContainer>
       <AmountContainer>
         <Text size="18px">How much are you spending today?</Text>
-        <AmountInput
-          onChange={handleAmount}
-          value={amount === 0 ? '' : amount}
-          placeholder={'$0.00'}
-          min="5"
-          max="10000"
-        />
+        <InputWrapper>
+          <AmountInput
+            onChange={handleAmount}
+            placeholder={'0.00'}
+            type="number"
+            error={!!error}
+          />
+        </InputWrapper>
       </AmountContainer>
       <MessageContainer>
         <Text size="16px" color="#DD678A" width="50%">
@@ -98,7 +103,9 @@ const Amount = (props: Props) => {
         <Voucher>
           Voucher Code: <Bold>{voucher.seller_gift_card_id}</Bold>{' '}
         </Voucher>
-        <NextButton onClick={(e) => setView(2)}>Next</NextButton>
+        <NextButton onClick={(e) => setView(2)} disabled={!!error}>
+          Next
+        </NextButton>
       </Footer>
     </Container>
   );
@@ -121,12 +128,21 @@ const Image = styled.img`
   max-width: 600px;
   margin: 0 auto;
 `;
+const InputWrapper = styled.div`
+  position: relative;
+  &:before {
+    position: absolute;
+    padding: 32px 0px 0px 16px;
+    content: '$';
+  }
+`;
 const AmountInput = styled.input`
-  padding: 12px;
+  padding: 12px 12px 12px 32px;
   height: 64px;
   font-size: 16px;
   width: 100%;
   margin: 12px auto;
-  border: 1px solid black;
+  border: 1px solid
+    ${(props: InputProps) => (props.error ? '#DD678A' : 'black')};
   border-radius: 5px;
 `;

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -43,7 +43,7 @@ const Amount = (props: Props) => {
 
   const handleAmount = (e) => {
     setError('');
-    if (e.target.value * 100 > voucher.amount || e.target.value * 100 < 5)
+    if (e.target.value * 100 > voucher.amount || e.target.value * 100 < 1)
       return setError('Please enter a valid amount');
     dispatch({ type: SET_AMOUNT, payload: e.target.value });
   };

--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -55,8 +55,15 @@ const Amount = (props: Props) => {
   return (
     <Container>
       <AmountContainer>
-        <Text width="100%" align="flex-start" onClick={(e) => setView(0)}>
-          {`< Cancel`}
+        <Text
+          width="100%"
+          align="flex-start"
+          color="#474747"
+          bold="true"
+          wide
+          onClick={(e) => setView(0)}
+        >
+          {`< CANCEL`}
         </Text>
       </AmountContainer>
 
@@ -73,7 +80,7 @@ const Amount = (props: Props) => {
           ${voucher.amount === 0 ? '0.00' : (voucher.amount / 100).toFixed(2)}
         </Text>
         <CurrentBalanceRow size="16px">
-          Current balance <MoreInfo showShadow={true} inverted={true} />
+          Current balance <MoreInfo showShadow inverted />
         </CurrentBalanceRow>
       </AmountContainer>
       <InputAreaWrapper>

--- a/src/pages/VoucherRedemption/Complete.tsx
+++ b/src/pages/VoucherRedemption/Complete.tsx
@@ -20,7 +20,7 @@ const Amount = (props: Props) => {
   };
 
   return (
-    <Footer height="90vh">
+    <Footer height="90vh" style={{flex: 1}}>
       <AmountContainer>
         <Text bold="true" size="24px">
           Redemption Complete

--- a/src/pages/VoucherRedemption/Complete.tsx
+++ b/src/pages/VoucherRedemption/Complete.tsx
@@ -26,12 +26,16 @@ const Amount = (props: Props) => {
           Redemption Complete
         </Text>
       </AmountContainer>
-      <AmountContainer>
-        <Text bold="true" size="24px">
-          $ {(amount / 100).toFixed(2)}
-        </Text>
-        <Text size="16px">Remaining voucher balance</Text>
-      </AmountContainer>
+      {!voucher.single_use ? (
+        <AmountContainer>
+          <Text bold="true" size="24px">
+            $ {(amount / 100).toFixed(2)}
+          </Text>
+          <Text size="16px">Remaining voucher balance</Text>
+        </AmountContainer>
+      ) : (
+        ''
+      )}
       <br />
       <Text size="24px" bold="true" width="80%" align="center">
         Thank you for dining at {voucher.ownerName}!

--- a/src/pages/VoucherRedemption/Complete.tsx
+++ b/src/pages/VoucherRedemption/Complete.tsx
@@ -20,7 +20,7 @@ const Amount = (props: Props) => {
   };
 
   return (
-    <Footer height="90vh" style={{flex: 1}}>
+    <Footer height="90vh" style={{ flex: 1 }}>
       <AmountContainer>
         <Text bold="true" size="24px">
           Redemption Complete

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -17,11 +17,12 @@ import MoreInfo from './MoreInfo';
 import Loader from '../../components/Loader';
 import {
   AmountContainer,
-  MessageConatiner,
+  MessageContainer,
   Text,
   Footer,
   NextButton,
   Divider,
+  Disclaimer,
 } from './styles';
 
 interface Props {}
@@ -71,7 +72,11 @@ const Amount = (props: Props) => {
   return (
     <Container>
       <AmountContainer>
-        <Text width="100%" align="flex-start" onClick={(e) => setView(1)}>
+        <Text
+          width="100%"
+          align="flex-start"
+          onClick={(e) => setView(voucher.single_use ? 0 : 1)}
+        >
           {`< Back`}
         </Text>
       </AmountContainer>
@@ -79,31 +84,44 @@ const Amount = (props: Props) => {
         Complete Your Purchase
         <MoreInfo marginLeft="35px" showShadow={true} />
       </Header>
-      <MessageConatiner>
+      {!voucher.single_use ? (
+        <MessageContainer>
+          <Text size="16px" width="50%">
+            Voucher balance
+          </Text>
+          <Text size="16px" width="50%" align="flex-end">
+            ${(voucher.amount / 100).toFixed(2)}
+          </Text>
+        </MessageContainer>
+      ) : (
+        ''
+      )}
+      <MessageContainer>
         <Text size="16px" width="50%">
-          Voucher balance
-        </Text>
-        <Text size="16px" width="50%" align="flex-end">
-          ${(voucher.amount / 100).toFixed(2)}
-        </Text>
-      </MessageConatiner>
-      <MessageConatiner>
-        <Text size="16px" width="50%">
-          Redemption Amount
+          {voucher.single_use
+            ? 'Single-use voucher balance'
+            : 'Redemption Amount'}
         </Text>
         <Text size="16px" width="50%" align="flex-end">
           ${(amount / 1).toFixed(2)}
         </Text>
-      </MessageConatiner>
+      </MessageContainer>
       <Divider />
-      <MessageConatiner>
-        <Text size="16px" width="50%">
-          Remaining balance
-        </Text>
-        <Text bold="true" size="24px" width="50%" align="flex-end">
-          ${(voucher.amount / 100 - amount).toFixed(2)}
-        </Text>
-      </MessageConatiner>
+      {!voucher.single_use ? (
+        <MessageContainer>
+          <Text size="16px" width="50%">
+            Remaining balance
+          </Text>
+          <Text bold="true" size="24px" width="50%" align="flex-end">
+            ${(voucher.amount / 100 - amount).toFixed(2)}
+          </Text>
+        </MessageContainer>
+      ) : (
+        <Disclaimer>
+          <strong>Note:</strong> Any remaining balance will not be redeemable
+          after this purchase
+        </Disclaimer>
+      )}
       <VoucherContainer>
         <Text>
           {' '}

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -81,8 +81,16 @@ const Amount = (props: Props) => {
         </Text>
       </AmountContainer>
       <Header>
-        Complete Your Purchase
-        <MoreInfo marginLeft="35px" showShadow={true} inverted={true}/>
+        {voucher.single_use ? (
+          <Text size="18px" width="70%">
+            Are you ready to redeem your voucher?
+          </Text>
+        ) : (
+          <Text size="22px">
+            Complete Your Purchase
+          </Text>
+        )}
+        <MoreInfo marginLeft="35px" showShadow={true} inverted={true} />
       </Header>
       {!voucher.single_use ? (
         <MessageContainer>

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -63,8 +63,8 @@ const Amount = (props: Props) => {
       dispatch({ type: SET_AMOUNT, payload: gift_card_detail.amount });
       setLoading(false);
       setView(3);
-    } catch (e) {
-      console.log('error: ', e);
+    } catch (err) {
+      console.log('error: ', err);
       setLoading(false);
     }
   };
@@ -82,7 +82,7 @@ const Amount = (props: Props) => {
       </AmountContainer>
       <Header>
         Complete Your Purchase
-        <MoreInfo marginLeft="35px" showShadow={true} />
+        <MoreInfo marginLeft="35px" showShadow={true} inverted={true}/>
       </Header>
       {!voucher.single_use ? (
         <MessageContainer>

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -23,6 +23,7 @@ import {
   NextButton,
   Divider,
   Disclaimer,
+  Bold,
 } from './styles';
 
 interface Props {}
@@ -132,8 +133,7 @@ const Amount = (props: Props) => {
       )}
       <VoucherContainer>
         <Text>
-          {' '}
-          Voucher Code: <b>{voucher.seller_gift_card_id}</b>{' '}
+          Voucher Code: &nbsp; <Bold>{voucher.seller_gift_card_id}</Bold>
         </Text>
       </VoucherContainer>
       <Footer>

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -77,9 +77,12 @@ const Amount = (props: Props) => {
         <Text
           width="100%"
           align="flex-start"
+          color="#474747"
+          bold="true"
+          wide
           onClick={(e) => setView(voucher.single_use ? 0 : 1)}
         >
-          {`< Back`}
+          {`< BACK`}
         </Text>
       </AmountContainer>
       <Header>

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -24,6 +24,7 @@ import {
   Divider,
   Disclaimer,
   Bold,
+  FlexFillSpace,
 } from './styles';
 
 interface Props {}
@@ -136,6 +137,7 @@ const Amount = (props: Props) => {
           Voucher Code: &nbsp; <Bold>{voucher.seller_gift_card_id}</Bold>
         </Text>
       </VoucherContainer>
+      <FlexFillSpace></FlexFillSpace>
       <Footer>
         <Text color="#ab192e" bold="true" width="50%" textAlign="center">
           Please show your phone to the merchant cashier to confirm the
@@ -157,6 +159,7 @@ const Container = styled.div`
   color: black;
   display: flex;
   flex-direction: column;
+  flex: 1;
 `;
 const Header = styled.div`
   position: relative;

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -91,9 +91,7 @@ const Amount = (props: Props) => {
             Are you ready to redeem your voucher?
           </Text>
         ) : (
-          <Text size="22px">
-            Complete Your Purchase
-          </Text>
+          <Text size="22px">Complete Your Purchase</Text>
         )}
         <MoreInfo marginLeft="35px" showShadow={true} inverted={true} />
       </Header>

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -46,7 +46,7 @@ const LandingCard = (props: Props) => {
         <br />
       </CardContainer>
       <br />
-      <Button color="#ab192e">{voucher.locations[0]}</Button>;
+      <Button color="#ab192e">{voucher.locations[0]}</Button>
       <FooterContainer>
         <Image src={Logo} />
       </FooterContainer>

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -14,7 +14,7 @@ import {
 
 interface Props {}
 interface ButtonProps {
-  color?: String;
+  color?: string;
 }
 const LandingCard = (props: Props) => {
   const { voucher } = useVoucherState();

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -7,7 +7,7 @@ import {
   useVoucherState,
   useVoucherDispatch,
 } from '../../utilities/hooks/VoucherContext/context';
-import { SET_VIEW } from '../../utilities/hooks/VoucherContext/constants';
+import { SET_VIEW, SET_AMOUNT } from '../../utilities/hooks/VoucherContext/constants';
 
 interface Props {}
 interface ButtonProps {
@@ -17,8 +17,14 @@ const LandingCard = (props: Props) => {
   const { voucher } = useVoucherState();
   const dispatch = useVoucherDispatch();
 
-  const setView = (e) => {
-    dispatch({ type: SET_VIEW, payload: 1 });
+  const setView = () => {
+    if (voucher.single_use) {
+      dispatch({ type: SET_AMOUNT, payload: voucher.amount/100 });
+      dispatch({ type: SET_VIEW, payload: 2 });
+    }
+    else {
+      dispatch({ type: SET_VIEW, payload: 1 });
+    }
   };
 
   return (

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -7,7 +7,10 @@ import {
   useVoucherState,
   useVoucherDispatch,
 } from '../../utilities/hooks/VoucherContext/context';
-import { SET_VIEW, SET_AMOUNT } from '../../utilities/hooks/VoucherContext/constants';
+import {
+  SET_VIEW,
+  SET_AMOUNT,
+} from '../../utilities/hooks/VoucherContext/constants';
 
 interface Props {}
 interface ButtonProps {
@@ -19,10 +22,9 @@ const LandingCard = (props: Props) => {
 
   const setView = () => {
     if (voucher.single_use) {
-      dispatch({ type: SET_AMOUNT, payload: voucher.amount/100 });
+      dispatch({ type: SET_AMOUNT, payload: voucher.amount / 100 });
       dispatch({ type: SET_VIEW, payload: 2 });
-    }
-    else {
+    } else {
       dispatch({ type: SET_VIEW, payload: 1 });
     }
   };
@@ -32,7 +34,11 @@ const LandingCard = (props: Props) => {
       <CardContainer>
         <VoucherContent>
           <SubText>
-            <SupportingText>{voucher.single_use ? 'Single-use voucher balance' : 'Your available balance'}</SupportingText>
+            <SupportingText>
+              {voucher.single_use
+                ? 'Single-use voucher balance'
+                : 'Your available balance'}
+            </SupportingText>
             <MoreInfo />
           </SubText>
           <Balance>${(voucher.amount / 100).toFixed(2)}</Balance>

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -26,7 +26,7 @@ const LandingCard = (props: Props) => {
       <CardContainer>
         <VoucherContent>
           <SubText>
-            <SupportingText>Your available balance</SupportingText>
+            <SupportingText>{voucher.single_use ? 'Single-use voucher balance' : 'Your available balance'}</SupportingText>
             <MoreInfo />
           </SubText>
           <Balance>${(voucher.amount / 100).toFixed(2)}</Balance>

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -3,15 +3,15 @@ import styled from 'styled-components';
 import { useVoucherState } from '../../utilities/hooks/VoucherContext/context';
 
 interface Props {
-  showShadow?: Boolean;
+  showShadow?: boolean;
   marginLeft?: string;
-  inverted?: Boolean;
+  inverted?: boolean;
 }
 interface VoucherInfoProps {
-  showInfo?: Boolean;
-  showShadow?: Boolean;
+  showInfo?: boolean;
+  showShadow?: boolean;
   marginLeft?: string;
-  inverted?: Boolean;
+  inverted?: boolean;
 }
 const LandingCard = (props: Props) => {
   const { voucher } = useVoucherState();
@@ -57,9 +57,9 @@ export default LandingCard;
  * @remarks The logic in this function is left intentionally verbose for clarity
  */
 const getColor = (
-  foreground: Boolean,
-  showInfo?: Boolean,
-  inverted?: Boolean
+  foreground: boolean,
+  showInfo?: boolean,
+  inverted?: boolean
 ): string => {
   const white = 'white';
   const red = '#ab192e';

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -77,7 +77,7 @@ const VoucherContent = styled.div`
   border-radius: 12px;
   margin-top: -7.5px;
   padding-top: 5px;
-  height: 270px;
+  height: ${(props: VoucherInfoProps) => props.showInfo ? '270px' : '25px'};
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -47,6 +47,15 @@ const LandingCard = (props: Props) => {
 
 export default LandingCard;
 
+/**
+ * Get the appropriate color of an element on the MoreInfo tooltip
+ *
+ * @param foreground whether the item is in the foreground or background of the icon
+ * @param showInfo whether the full help text is popped open
+ * @param inverted whether to invert the icon as red-on-white, instead of the usual white-on-red
+ *
+ * @remarks The logic in this function is left intentionally verbose for clarity
+ */
 const getColor = (
   foreground: Boolean,
   showInfo?: Boolean,

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -5,15 +5,18 @@ import { useVoucherState } from '../../utilities/hooks/VoucherContext/context';
 interface Props {
   showShadow?: Boolean;
   marginLeft?: string;
+  inverted?: Boolean;
 }
 interface VoucherInfoProps {
   showInfo?: Boolean;
   showShadow?: Boolean;
   marginLeft?: string;
+  inverted?: Boolean;
 }
 const LandingCard = (props: Props) => {
   const { voucher } = useVoucherState();
   const [showInfo, setShowInfo] = useState(false);
+
   return (
     <VoucherContent
       showInfo={showInfo}
@@ -33,6 +36,7 @@ const LandingCard = (props: Props) => {
       )}
       <MoreInfoButton
         showInfo={showInfo}
+        inverted={props.inverted}
         onClick={(e) => setShowInfo(!showInfo)}
       >
         ?
@@ -42,6 +46,27 @@ const LandingCard = (props: Props) => {
 };
 
 export default LandingCard;
+
+const getColor = (foreground: Boolean, showInfo?: Boolean, inverted?: Boolean): string => {
+  const white = 'white';
+  const red = '#ab192e';
+
+  if (!inverted) {
+    if (foreground) {
+      return !showInfo ? red : white;
+    }
+    else {
+      return !showInfo ? white : red;
+    }
+  } else {
+    if (foreground) {
+      return white;
+    }
+    else {
+      return red;
+    }
+  }
+};
 
 const VoucherContent = styled.div`
   z-index: 150 !important;
@@ -82,9 +107,10 @@ const MoreInfoButton = styled.div`
   position: absolute;
   right: 10px;
   border: 1px solid transparent;
-  color: ${(props: VoucherInfoProps) => (props.showInfo ? `white` : `#ab192e`)};
+  color: ${(props: VoucherInfoProps) =>
+    getColor(true, props.showInfo, props.inverted)};
   background-color: ${(props: VoucherInfoProps) =>
-    props.showInfo ? `#ab192e` : `white`};
+    getColor(false, props.showInfo, props.inverted)};
   border-radius: 50%;
   width: 25px;
   text-align: center;

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -47,22 +47,24 @@ const LandingCard = (props: Props) => {
 
 export default LandingCard;
 
-const getColor = (foreground: Boolean, showInfo?: Boolean, inverted?: Boolean): string => {
+const getColor = (
+  foreground: Boolean,
+  showInfo?: Boolean,
+  inverted?: Boolean
+): string => {
   const white = 'white';
   const red = '#ab192e';
 
   if (!inverted) {
     if (foreground) {
       return !showInfo ? red : white;
-    }
-    else {
+    } else {
       return !showInfo ? white : red;
     }
   } else {
     if (foreground) {
       return white;
-    }
-    else {
+    } else {
       return red;
     }
   }
@@ -77,7 +79,7 @@ const VoucherContent = styled.div`
   border-radius: 12px;
   margin-top: -7.5px;
   padding-top: 5px;
-  height: ${(props: VoucherInfoProps) => props.showInfo ? '270px' : '25px'};
+  height: ${(props: VoucherInfoProps) => (props.showInfo ? '270px' : '25px')};
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/pages/VoucherRedemption/VoucherRedemption.tsx
+++ b/src/pages/VoucherRedemption/VoucherRedemption.tsx
@@ -99,8 +99,5 @@ const Container = styled.div`
   height: 100vh;
   background-color: transparent;
   flex-direction: column;
-  * {
-    z-index: 10;
-  }
   overflow-x: hidden;
 `;

--- a/src/pages/VoucherRedemption/VoucherRedemption.tsx
+++ b/src/pages/VoucherRedemption/VoucherRedemption.tsx
@@ -98,6 +98,7 @@ const Container = styled.div`
   `}
   height: 100vh;
   background-color: transparent;
+  display: flex;
   flex-direction: column;
   overflow-x: hidden;
 `;

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -80,7 +80,7 @@ const Footer = styled.div`
 `;
 
 const NextButton = styled.button`
-  background: ${props => props.disabled ? 'grey' : 'black'};
+  background: ${(props) => (props.disabled ? 'grey' : 'black')};
   color: white;
   font-size: 18px;
   border-radius: 32px;
@@ -101,7 +101,7 @@ const Divider = styled.div`
 const Disclaimer = styled.div`
   text-align: center;
   font-size: 16px;
-  color: #A8192E;
+  color: #a8192e;
   padding-bottom: 3vh;
 `;
 
@@ -119,5 +119,5 @@ export {
   Voucher,
   Bold,
   Disclaimer,
-  FlexFillSpace
+  FlexFillSpace,
 };

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -93,8 +93,7 @@ const NextButton = styled.button`
 `;
 
 const Divider = styled.div`
-  border-bottom: 1px solid
-    ${(props: VoucherInfoProps) => (!props.showInfo ? 'white' : 'transparent')};
+  border-bottom: 2px solid #f7f7f7;
   margin: 12px auto;
   width: 90%;
 `;

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -1,17 +1,17 @@
 import styled from 'styled-components';
 
 interface TextProps {
-  bold?: String;
-  color?: String;
-  size?: String;
-  width?: String;
-  align?: String;
-  textAlign?: String;
-  padding?: String;
-  wide?: Boolean;
+  bold?: string;
+  color?: string;
+  size?: string;
+  width?: string;
+  align?: string;
+  textAlign?: string;
+  padding?: string;
+  wide?: boolean;
 }
 interface VoucherInfoProps {
-  showInfo?: Boolean;
+  showInfo?: boolean;
 }
 interface ContainerProps {
   height?: string;

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -28,7 +28,7 @@ const AmountContainer = styled.div`
   ${(props: ContainerProps) =>
     props.bringToTheFront && 'z-index: 150!important;'}
 `;
-const MessageConatiner = styled.div`
+const MessageContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -96,13 +96,21 @@ const Divider = styled.div`
   width: 90%;
 `;
 
+const Disclaimer = styled.div`
+  text-align: center;
+  font-size: 16px;
+  color: #A8192E;
+  padding-bottom: 3vh;
+`;
+
 export {
   AmountContainer,
-  MessageConatiner,
+  MessageContainer,
   Text,
   Footer,
   NextButton,
   Divider,
   Voucher,
   Bold,
+  Disclaimer
 };

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -47,6 +47,7 @@ const Voucher = styled.div`
 const Bold = styled.span`
   font-weight: 600;
   word-wrap: break-word;
+  word-break: break-all;
 `;
 const Text = styled.div`
   display: flex;
@@ -77,7 +78,7 @@ const Footer = styled.div`
 `;
 
 const NextButton = styled.button`
-  background: black;
+  background: ${props => props.disabled ? 'grey' : 'black'};
   color: white;
   font-size: 18px;
   border-radius: 32px;

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -8,6 +8,7 @@ interface TextProps {
   align?: String;
   textAlign?: String;
   padding?: String;
+  wide?: Boolean;
 }
 interface VoucherInfoProps {
   showInfo?: Boolean;
@@ -62,6 +63,7 @@ const Text = styled.div`
   ${(props: TextProps) => props.align && `justify-content: ${props.align};`}
   ${(props: TextProps) => props.textAlign && `text-align: ${props.textAlign};`}
   ${(props: TextProps) => props.padding === 'true' && `padding-right: 5px;`}
+  ${(props: TextProps) => props.wide && `letter-spacing: 3px;`}
   span {
     font-weight: 700;
   }

--- a/src/pages/VoucherRedemption/styles.ts
+++ b/src/pages/VoucherRedemption/styles.ts
@@ -104,6 +104,10 @@ const Disclaimer = styled.div`
   padding-bottom: 3vh;
 `;
 
+const FlexFillSpace = styled.div`
+  flex: 1;
+`;
+
 export {
   AmountContainer,
   MessageContainer,
@@ -113,5 +117,6 @@ export {
   Divider,
   Voucher,
   Bold,
-  Disclaimer
+  Disclaimer,
+  FlexFillSpace
 };

--- a/src/utilities/api/interactionManager.ts
+++ b/src/utilities/api/interactionManager.ts
@@ -117,7 +117,7 @@ export const updateVoucher = async (id: string, amount: number) =>
     .put(vouchers + id, { amount })
     .then((res) => res)
     .catch((err) => err);
-          
+
 function localeFromLanguage(language?: string) {
   switch (language) {
     case 'cn':

--- a/src/utilities/hooks/VoucherContext/types.ts
+++ b/src/utilities/hooks/VoucherContext/types.ts
@@ -23,6 +23,7 @@ export type VoucherDetails = {
   storeImage: string;
   sellerID: string;
   locations: Array<number | null>;
+  single_use: boolean;
 };
 export type VoucherState = {
   amount: number;
@@ -49,5 +50,6 @@ export const defaultState: VoucherState = {
     storeImage: '',
     sellerID: '',
     locations: [],
+    single_use: false
   },
 };

--- a/src/utilities/hooks/VoucherContext/types.ts
+++ b/src/utilities/hooks/VoucherContext/types.ts
@@ -50,6 +50,6 @@ export const defaultState: VoucherState = {
     storeImage: '',
     sellerID: '',
     locations: [],
-    single_use: false
+    single_use: false,
   },
 };


### PR DESCRIPTION
New:
- Added checks for single_use variable and modifying the pages and flow when this is true
- Various text changes when in the single_use flow

Changes to both flows:
- Improved error handling on the amount input box
  - Accepts inputs between 5¢ and the full amount
  - Error state now disables and greys out the "Next" Button
  - Error state changes the border to red
- Added floating $ sign to input box
- Fixed logic on when to invert the colors for the More Info tool tip (code is intentionally verbose to be more readable)
- Flexbox changes to allow spacing to be added more naturally on different size devices
- Changed the back / cancel buttons to more closely match the Figma design
- Removed the z-index the More Info div which was blocking the input box when not popped out

General code cleanup:
- Fixed some spelling errors
- Removed rogue end comment tag
- Removed a rogue ;

Verified amount changes persist to the db ✓

---

Screenshots of both flows: 
 - Shown on iPhone X size
 - Other states shown in multi-flow work for single-flow as well)

Multi flow:
![Redemption Multi Flow](https://user-images.githubusercontent.com/2818246/84324640-fa159400-ab46-11ea-9ab1-7ef23b612cf7.png)

Single flow:
![Redemption Single Flow](https://user-images.githubusercontent.com/2818246/84324643-fbdf5780-ab46-11ea-8ca8-cadd5742830a.png)
