### PR TITLE
Fixed critical bug with location rendering in the redemption flow

### DIFF
--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -26,6 +26,7 @@ import {
   Bold,
   FlexFillSpace,
 } from './styles';
+import { getLocationInfo } from '../../utilities/hooks/helpers';
 
 interface Props {}
 interface ContainerProps {
@@ -58,7 +59,7 @@ const Amount = (props: Props) => {
         ownerImage: merchantData.data.owner_image_url,
         storeImage: merchantData.data.hero_image_url,
         sellerID: seller_id,
-        locations: merchantData.data.locations,
+        location: getLocationInfo(merchantData),
       };
 
       dispatch({ type: SET_VOUCHER_INFO, payload: newVoucher });

--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -52,7 +52,11 @@ const LandingCard = (props: Props) => {
         <br />
       </CardContainer>
       <br />
-      <Button color="#ab192e">{voucher.locations[0]}</Button>
+      <Button color="#ab192e">
+        {voucher.location.line1}
+        <br></br>
+        {voucher.location.line2}
+      </Button>
       <FooterContainer>
         <Image src={Logo} />
       </FooterContainer>
@@ -107,9 +111,9 @@ const SupportingText = styled.span`
 `;
 const Button = styled.div`
   cursor: pointer;
-  ${(props: ButtonProps) => props.color && `color: ${props.color}`}
+  ${(props: ButtonProps) => `color: ${props.color ?? ''};`}
   font-size: 13px;
-  line-height: 18px;
+  line-height: 1.5;
   text-align: center;
 `;
 const Balance = styled.div`

--- a/src/pages/VoucherRedemption/VoucherRedemption.tsx
+++ b/src/pages/VoucherRedemption/VoucherRedemption.tsx
@@ -15,6 +15,7 @@ import { SET_VOUCHER_INFO } from '../../utilities/hooks/VoucherContext/constants
 import Loader from '../../components/Loader';
 import NYCBackdrop from '../../images/nyc-background.png';
 import { getVoucher, getSeller } from '../../utilities/api/interactionManager';
+import { getLocationInfo } from '../../utilities/hooks/helpers';
 
 interface Props {}
 interface ContainerProps {
@@ -40,7 +41,7 @@ const VoucherRedemption = (props: Props) => {
         ownerImage: merchantData.data.owner_image_url,
         storeImage: merchantData.data.hero_image_url,
         sellerID: seller_id,
-        locations: merchantData.data.locations,
+        location: getLocationInfo(merchantData),
       };
 
       dispatch({ type: SET_VOUCHER_INFO, payload: voucher });

--- a/src/utilities/hooks/VoucherContext/types.ts
+++ b/src/utilities/hooks/VoucherContext/types.ts
@@ -22,13 +22,17 @@ export type VoucherDetails = {
   ownerImage: string;
   storeImage: string;
   sellerID: string;
-  locations: Array<number | null>;
   single_use: boolean;
+  location: LocationInfo;
 };
 export type VoucherState = {
   amount: number;
   view: number;
   voucher: VoucherDetails;
+};
+export type LocationInfo = {
+  line1: string;
+  line2: string;
 };
 
 export const defaultState: VoucherState = {
@@ -49,7 +53,10 @@ export const defaultState: VoucherState = {
     ownerImage: '',
     storeImage: '',
     sellerID: '',
-    locations: [],
     single_use: false,
+    location: {
+      line1: '',
+      line2: '',
+    },
   },
 };

--- a/src/utilities/hooks/helpers.ts
+++ b/src/utilities/hooks/helpers.ts
@@ -1,0 +1,23 @@
+import { LocationInfo } from '../../utilities/hooks/VoucherContext/types';
+
+export const getLocationInfo = (merchantData): LocationInfo => {
+  const emptyLocationInfo = {
+    line1: '',
+    line2: '',
+  };
+  const locations = merchantData?.data?.locations;
+  if (!locations || !(locations.length > 0)) {
+    return emptyLocationInfo;
+  }
+  const location = locations[0];
+  if (!location) {
+    return emptyLocationInfo;
+  }
+  const locationInfo = {
+    line1: `${location.address1 ?? ''} ${location.address2 ?? ''}`,
+    line2: `${location.city ?? ''} ${location.state ?? ''}, ${
+      location.zip_code ?? ''
+    }`,
+  };
+  return locationInfo;
+};


### PR DESCRIPTION
-This fixes a bug which causes the redemption flow to break because it can't render the location from the backend correctly.
-Also fixes a minor bug where the `color` prop in the `Button` component wasn't being set properly due to a missing semicolon

Before:
<img width="418" alt="Screen Shot 2020-06-13 at 3 55 47 PM" src="https://user-images.githubusercontent.com/2313868/84577941-8f569980-ad8e-11ea-8af5-80c3ad443558.png">

After:
<img width="410" alt="Screen Shot 2020-06-13 at 4 10 13 PM" src="https://user-images.githubusercontent.com/2313868/84578137-79e26f00-ad90-11ea-8d75-b80ef688ce24.png">
