### PR TITLE
Make entire card tappable in redemption flow

### DIFF
--- a/src/pages/VoucherRedemption/Landing.tsx
+++ b/src/pages/VoucherRedemption/Landing.tsx
@@ -31,7 +31,7 @@ const LandingCard = (props: Props) => {
 
   return (
     <Container>
-      <CardContainer>
+      <CardContainer onClick={setView}>
         <VoucherContent>
           <SubText>
             <SupportingText>
@@ -48,7 +48,7 @@ const LandingCard = (props: Props) => {
           <br />
         </VoucherContent>
         <Divider />
-        <Button onClick={setView}>Click to begin redeeming your voucher</Button>
+        <Button>Click to begin redeeming your voucher</Button>
         <br />
       </CardContainer>
       <br />

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -24,7 +24,13 @@ const LandingCard = (props: Props) => {
       marginLeft={props.marginLeft}
     >
       {showInfo && (
-        <SubText showInfo={showInfo}>
+        <SubText
+          showInfo={showInfo}
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowInfo(!showInfo);
+          }}
+        >
           By proceeding with your purchase, you understand that the voucher card
           is not redeemable for cash and can only be used at Shunfa Bakery. All
           purchases are final. In the event that the merchant is no longer open
@@ -37,7 +43,10 @@ const LandingCard = (props: Props) => {
       <MoreInfoButton
         showInfo={showInfo}
         inverted={props.inverted}
-        onClick={(e) => setShowInfo(!showInfo)}
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowInfo(!showInfo);
+        }}
       >
         ?
       </MoreInfoButton>


### PR DESCRIPTION
Talked to @nanxiy , we want to make the entire voucher card tappable in the redemption flow instead of just the "click to begin redeeming your voucher" text. The info icon and tooltip still handle tap separately.

Test plan:
![voucher-click](https://user-images.githubusercontent.com/2313868/84599634-73600000-ae41-11ea-899f-6c27efd42e36.gif)
