### PR TITLE
Disable payment confirm button after form submission

### DIFF
--- a/src/components/ModalPayment/SquareModal.tsx
+++ b/src/components/ModalPayment/SquareModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { times } from 'lodash/fp';
 import { Checkbox } from '@material-ui/core';
 import { SquarePaymentForm } from 'react-square-payment-form';
@@ -47,6 +47,7 @@ const SquareModal = ({
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [errorMessages, setErrorsMessages] = useState<string[]>([]);
+  const [canSubmit, setCanSubmit] = useState(false);
 
   const checkTermsAgreement = () => setTermsChecked(!isTermsChecked);
   const checkSubscriptionAgreement = () =>
@@ -95,6 +96,7 @@ const SquareModal = ({
       is_subscribed: isSubscriptionChecked,
     };
 
+    setCanSubmit(false)
     return makeSquarePayment(nonce, sellerId, payment, buyer, is_distribution)
       .then((res) => {
         if (res.status === 200) {
@@ -146,11 +148,12 @@ const SquareModal = ({
     }
   };
 
-  const canSubmit =
-    isTermsChecked &&
-    name.length > 0 &&
-    email.length > 0 &&
-    EMAIL_REGEX.test(email);
+  useEffect(() => {
+    setCanSubmit(isTermsChecked &&
+      name.length > 0 &&
+      email.length > 0 &&
+      EMAIL_REGEX.test(email));
+  }, [isTermsChecked, name, email])
 
   const setDisclaimerLanguage = (type: string) => {
     if (sellerId === 'send-chinatown-love') type = 'donation-pool';

--- a/src/index.scss
+++ b/src/index.scss
@@ -164,6 +164,7 @@ h3 {
   &--outline:disabled {
     background-color: grey;
     border: 1px solid grey;
+    cursor: default;
   }
 
   &--filled:enabled:hover {


### PR DESCRIPTION
This PR fixes https://github.com/sendchinatownlove/sendchinatownlove.github.io/issues/175
- Disabled submit button after payment submission, Square will also block duplicate payment on their side though, thus this issue should not be a priority.
- Changed the disabled button cursor style to default.


Before (I'm keeping clicking the submit button, and you could see the request do have been sent multiple times):
![before](https://user-images.githubusercontent.com/12378652/84665214-9516c100-aeed-11ea-8015-bf6955091b7e.gif)

After:
![after](https://user-images.githubusercontent.com/12378652/84665729-2ede6e00-aeee-11ea-9342-25266784eb6a.gif)
