### PR TITLE
Fixed owner name bug in redemption flow

### DIFF
--- a/src/pages/VoucherRedemption/Amount.tsx
+++ b/src/pages/VoucherRedemption/Amount.tsx
@@ -21,7 +21,7 @@ import {
   FlexFillSpace,
 } from './styles';
 
-interface Props { }
+interface Props {}
 interface TextProps {
   bold?: string;
   color?: string;
@@ -80,7 +80,7 @@ const Amount = (props: Props) => {
             ? process.env.REACT_APP_BASE_URL + voucher.storeImage
             : defaultStoreFront
         }
-        alt={`${voucher.ownerName} Illustration`}
+        alt={`${voucher.storeName} Illustration`}
       />
       <AmountContainer bringToTheFront>
         <Text bold="true" size="24px">
@@ -122,7 +122,10 @@ const Amount = (props: Props) => {
         <Voucher>
           Voucher Code: <Bold>{voucher.seller_gift_card_id}</Bold>{' '}
         </Voucher>
-        <NextButton onClick={(e) => setView(2)} disabled={!!error || amount <= 0}>
+        <NextButton
+          onClick={(e) => setView(2)}
+          disabled={!!error || amount <= 0}
+        >
           Next
         </NextButton>
       </Footer>

--- a/src/pages/VoucherRedemption/Complete.tsx
+++ b/src/pages/VoucherRedemption/Complete.tsx
@@ -38,7 +38,7 @@ const Amount = (props: Props) => {
       )}
       <br />
       <Text size="24px" bold="true" width="80%" align="center">
-        Thank you for dining at {voucher.ownerName}!
+        Thank you for dining at {voucher.storeName}!
       </Text>
       <br />
       <br />

--- a/src/pages/VoucherRedemption/Confirm.tsx
+++ b/src/pages/VoucherRedemption/Confirm.tsx
@@ -58,6 +58,7 @@ const Amount = (props: Props) => {
         ownerName: merchantData.data.owner_name,
         ownerImage: merchantData.data.owner_image_url,
         storeImage: merchantData.data.hero_image_url,
+        storeName: merchantData.data.name,
         sellerID: seller_id,
         location: getLocationInfo(merchantData),
       };

--- a/src/pages/VoucherRedemption/MoreInfo.tsx
+++ b/src/pages/VoucherRedemption/MoreInfo.tsx
@@ -37,7 +37,7 @@ const LandingCard = (props: Props) => {
           at the time of redemption, Send Chinatown Love Inc. will not be able
           to refund your purchase. Balance displayed in the voucher may or may
           not represent the final balance. Final balance information is subject
-          to {voucher.ownerName}'s most recent records.
+          to {voucher.storeName}'s most recent records.
         </SubText>
       )}
       <MoreInfoButton

--- a/src/pages/VoucherRedemption/StoreBanner.tsx
+++ b/src/pages/VoucherRedemption/StoreBanner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useVoucherState } from '../../utilities/hooks/VoucherContext/context';
 import Logo from '../../components/Logos/image/PureLogo.png';
-import DefaultOwnerImage from '../../images/female.svg';
+import DefaultStoreImage from '../../images/misc-store.png';
 
 interface Props {}
 interface ContainerProps {
@@ -20,15 +20,15 @@ const StoreBanner = (props: Props) => {
         isOnLandingPage={isOnLandingPage}
         src={
           isOnLandingPage
-            ? voucher?.ownerImage
-              ? process.env.REACT_APP_BASE_URL + voucher?.ownerImage
-              : DefaultOwnerImage
+            ? voucher?.storeImage
+              ? process.env.REACT_APP_BASE_URL + voucher?.storeImage
+              : DefaultStoreImage
             : Logo
         }
       />
       <Header isOnLandingPage={isOnLandingPage}>
         {isOnLandingPage && 'Welcome to '}
-        {voucher.ownerName}
+        {voucher.storeName}
       </Header>
     </Container>
   );
@@ -61,7 +61,7 @@ const Header = styled.h1`
 const OwnerImage = styled.img`
   width: ${(props: ContainerProps) =>
     props.isOnLandingPage ? '150px' : '55px'};
-  // height: ${(props: ContainerProps) =>
+  height: ${(props: ContainerProps) =>
     props.isOnLandingPage ? '150px' : '100px'};
   ${(props: ContainerProps) =>
     props.isOnLandingPage && 'border: 5px solid white;'}

--- a/src/pages/VoucherRedemption/VoucherRedemption.tsx
+++ b/src/pages/VoucherRedemption/VoucherRedemption.tsx
@@ -37,9 +37,8 @@ const VoucherRedemption = (props: Props) => {
 
       const voucher = {
         ...gift_card_detail,
-        ownerName: merchantData.data.owner_name,
-        ownerImage: merchantData.data.owner_image_url,
         storeImage: merchantData.data.hero_image_url,
+        storeName: merchantData.data.name,
         sellerID: seller_id,
         location: getLocationInfo(merchantData),
       };

--- a/src/utilities/hooks/VoucherContext/types.ts
+++ b/src/utilities/hooks/VoucherContext/types.ts
@@ -18,9 +18,8 @@ export type VoucherDetails = {
   recipient_id: number;
   seller_gift_card_id: string;
   updated_at: string;
-  ownerName: string;
-  ownerImage: string;
   storeImage: string;
+  storeName: string;
   sellerID: string;
   single_use: boolean;
   location: LocationInfo;
@@ -49,9 +48,8 @@ export const defaultState: VoucherState = {
     recipient_id: -1,
     seller_gift_card_id: '',
     updated_at: '',
-    ownerName: '',
-    ownerImage: '',
     storeImage: '',
+    storeName: '',
     sellerID: '',
     single_use: false,
     location: {


### PR DESCRIPTION
Fixed bug where the owner name and image was showing up instead of the store name and image
Test plan:
<img width="418" alt="Screen Shot 2020-06-16 at 10 56 46 PM" src="https://user-images.githubusercontent.com/2313868/84850665-4ae52b00-b026-11ea-8f73-b7baeaa407c7.png">
<img width="415" alt="Screen Shot 2020-06-16 at 10 57 05 PM" src="https://user-images.githubusercontent.com/2313868/84850668-4de01b80-b026-11ea-9197-28c014ebe3b4.png">
<img width="412" alt="Screen Shot 2020-06-16 at 11 00 15 PM" src="https://user-images.githubusercontent.com/2313868/84850671-50427580-b026-11ea-816b-c61587f9a91a.png">
<img width="417" alt="Screen Shot 2020-06-16 at 11 04 56 PM" src="https://user-images.githubusercontent.com/2313868/84850674-52a4cf80-b026-11ea-9d47-7209bbc71eae.png">
