### PR TITLE
Hover on merchant progress bar/format dollar amounts

### DIFF
--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import { withStyles, Theme } from '@material-ui/core/styles';
-
 import styled from 'styled-components';
 
 interface Props {
@@ -42,6 +41,34 @@ const ProgressBar = ({
 
   return (
     <ProgressBarContainer>
+      <SupporterTooltip
+            title={
+              <React.Fragment>
+                <ToolTipTable>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <b>{numGiftCards}</b> vouchers
+                      </td>
+                      <td>
+                        <b>${Math.floor(giftCardAmount / 100).toLocaleString()}</b>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <b>{numDonations}</b> donations
+                      </td>
+                      <td>
+                        <b>${Math.floor(donationAmount / 100).toLocaleString()}</b>
+                      </td>
+                    </tr>
+                  </tbody>
+                </ToolTipTable>
+              </React.Fragment>
+            }
+            enterTouchDelay={50}
+            placement="top"
+          >
       <TargetAmountBar className="progress-bar">
         <CurrentProgressBar
           style={{
@@ -53,44 +80,16 @@ const ProgressBar = ({
           {' '}
         </CurrentProgressBar>
       </TargetAmountBar>
+      </SupporterTooltip>
       <ContributionInfoContainer>
         <div>
           ${Math.floor(amountRaised / 100).toLocaleString()} of $
           {Math.floor(targetAmount / 100).toLocaleString()}
         </div>
         <div>
-          <SupporterTooltip
-            title={
-              <React.Fragment>
-                <ToolTipTable>
-                  <tbody>
-                    <tr>
-                      <td>
-                        <b>{numGiftCards}</b> vouchers
-                      </td>
-                      <td>
-                        <b>${Math.floor(giftCardAmount) / 100}</b>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>{numDonations}</b> donations
-                      </td>
-                      <td>
-                        <b>${Math.floor(donationAmount) / 100}</b>
-                      </td>
-                    </tr>
-                  </tbody>
-                </ToolTipTable>
-              </React.Fragment>
-            }
-            enterTouchDelay={50}
-            placement="top"
-          >
             <div>
               <b>{numContributions}</b> supporters
             </div>
-          </SupporterTooltip>
         </div>
       </ContributionInfoContainer>
     </ProgressBarContainer>


### PR DESCRIPTION
**Changes made**:
1.	Vouchers/Donations hover when cursor is on progress bar (instead of the supporters text)
2.	Formatted the voucher and donations dollar amount to be consistent with amount raised and target amount below it (before: $2960, after: $2,960) . 

**Before**: 
![image](https://user-images.githubusercontent.com/37196330/89666848-b0c09700-d8a0-11ea-8701-dc48ae3200aa.png)

**After**:
![hoverprogressbar](https://user-images.githubusercontent.com/37196330/89665681-a30a1200-d89e-11ea-9d2f-80d8eab404db.gif)

Suggestions:
1.	Do we also want to round the amounts in the box (e.g. $916.75 to $916)?
2.	The tooltip placement covers the merchant description (on all merchants page) and the merchant name (on individual merchant page). Do want to change this to bottom or leave as it is? 

**Current (top placement)**:
![image](https://user-images.githubusercontent.com/37196330/89666030-46f3bd80-d89f-11ea-9e05-fa90290d0d0c.png)![image](https://user-images.githubusercontent.com/37196330/89666026-4529fa00-d89f-11ea-8028-1e1b0c40eda0.png)

**Bottom placement**:
![image](https://user-images.githubusercontent.com/37196330/89666337-cd100400-d89f-11ea-9e97-a61643e3912a.png)![image](https://user-images.githubusercontent.com/37196330/89666066-5a068d80-d89f-11ea-9d4a-f54e15090688.png)
