### PR TITLE
FIX: Donate nav link

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -73,7 +73,7 @@ const App = () => {
       <>
         <ModalPaymentProvider>
           <ScrollToTop />
-          <Header menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+          <Header menuOpen={menuOpen} setMenuOpen={setMenuOpen} pageName={child} />
           {component}
           <Footer menuOpen={menuOpen} />
         </ModalPaymentProvider>

--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -5,12 +5,13 @@ import MenuIcon from '@material-ui/icons/Menu';
 import CloseIcon from '@material-ui/icons/Close';
 import { Logo } from '../Logos';
 import { useTranslation } from 'react-i18next';
-import { matchPath } from 'react-router';
 
 interface Props {
   menuOpen: boolean;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  pageName: string;
 }
+
 interface CompactProps {
   compact: string;
   href?: string;
@@ -37,10 +38,7 @@ const NavBar = (props: Props) => {
     }
   };
 
-  const isMerchantsPathActive = !!matchPath(
-    window.location.pathname,
-    '/merchants'
-  );
+  const isMerchantsPathActive = props.pageName === 'all';
 
   useEffect(() => {
     if (window.innerWidth < 1025) {
@@ -177,6 +175,7 @@ const HeaderContainer = styled.header`
   font-size: 14px;
   font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
 `;
+
 const NavLinksContainer = styled.div`
   display: flex;
   flex-direction: ${(props: CompactProps) =>
@@ -198,6 +197,7 @@ const NavLinksContainer = styled.div`
     justify-content: flex-end;
   `}
 `;
+
 const HamburgerContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -247,6 +247,7 @@ const LanguageContainer = styled.div`
   margin-left: 20px;
   ${(props: CompactProps) => props.compact === 'true' && 'margin-right: 20px;'}
 `;
+
 const LanguageButton = styled.div`
   margin: 0;
   transition: 0.1s;
@@ -259,6 +260,7 @@ const LanguageButton = styled.div`
   }
   width: 35px;
 `;
+
 const ReactNavLink = styled(Link)`
   text-decoration: none;
   color: black;
@@ -274,7 +276,8 @@ const ReactNavLink = styled(Link)`
   ${(props: CompactProps) =>
     props.active === 'true' &&
     `
-    border-bottom: 1.5px #9e9e9e solid;
+    border-bottom: 1px #9e9e9e solid;
+    padding: 0 5px 3px;
   `} :link {
     color: black;
   }
@@ -282,6 +285,7 @@ const ReactNavLink = styled(Link)`
     color: #9e9e9e;
   }
 `;
+
 const Close = styled(CloseIcon)`
   cursor: pointer;
 `;


### PR DESCRIPTION
I noticed the bottom border under Donate in the nav bar is not showing when it's the active page. I could have changed  '/merchants' to  '/all'' in `isMerchantsPathActive` but I did some refactoring (heh). Let me know if you want me to revert to what we had. I also added some styling to make it closer to the Weebly underline.

**Currently:**
https://merchant.sendchinatownlove.com/all
![image](https://user-images.githubusercontent.com/37196330/89976265-98000a80-dc2d-11ea-9f62-1dafbcfbca32.png)

**Now:**
![image](https://user-images.githubusercontent.com/37196330/89976273-9df5eb80-dc2d-11ea-9066-7ff46f58a35b.png)

**Compared to Weebly's underline**
![image](https://user-images.githubusercontent.com/37196330/89976449-12308f00-dc2e-11ea-939d-b3585dd1a940.png)

