### PR TITLE
Enforce image size limits for Campaign List Item

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import CampaignProgressBar from './CampaignProgressBar';
 import styled from 'styled-components';
 import {
-  tabletScreens
+  tabletScreens, desktopScreens
 } from '../../../utilities/general/responsive';
 import campaignDefaultImage from '../images/campaign_default.png';
 import { Campaign } from '../../../utilities/api/types';
@@ -38,7 +38,7 @@ const CampaignListItem = (props: Props) => {
     <Container>
       <ColumnContainer>
         {campaignImageUrls && campaignImageUrls.length && (
-          <img src={campaignImageUrls[0] ?? campaignDefaultImage} alt="campaign_image" />
+          <CampaignImage src={campaignImageUrls[0] ?? campaignDefaultImage} alt="campaign_image" />
         )}
       </ColumnContainer>
       <ColumnContainer>
@@ -68,12 +68,12 @@ const CampaignListItem = (props: Props) => {
         <ImagesContainer>
           {distributor &&
             (<a href={distributor.website_url}>
-              <img src={distributor.image_url} style={{ margin: '0 15px' }} alt="distributor_logo" />
+              <DistributorImage src={distributor.image_url} alt="distributor_logo" />
             </a>
             )
           }
           {merchant &&
-            (<img src={merchant.logo_image_url} alt="merchant_logo" />)
+            (<MerchantImage src={merchant.logo_image_url} alt="merchant_logo" />)
           }
         </ImagesContainer>
         {merchant && (
@@ -212,4 +212,29 @@ const ImagesContainer = styled.span`
       height: 25px;
     }
   }
+`;
+
+const CampaignImage = styled.img`
+  @media (${tabletScreens}) {
+    max-height: 100px;
+    width: 100%;
+  }
+
+  @media (${desktopScreens}) {
+    max-height: 240px;
+    max-width: 240px;
+  }
+`;
+
+const DistributorImage = styled.img`
+  max-height: 70px;
+  max-width: 120px;
+  margin-right: 15px;
+  vertical-align: middle;
+`;
+
+const MerchantImage = styled.img`
+  max-height: 70px;
+  max-width: 70px;
+  vertical-align: middle;
 `;


### PR DESCRIPTION
https://merchant.sendchinatownlove.com/gift-a-meal-home is currently messed up because the images are too large. Adding image size limits 

Test plan:
-Seeded DB with large merchant logo images, verified they render correctly
<img width="1533" alt="Screen Shot 2020-08-13 at 11 21 36 PM" src="https://user-images.githubusercontent.com/2313868/90210639-8436de80-ddbc-11ea-9bcf-9569ffdd45a4.png">
