### PR TITLE
Fixed Campaign image sizing issue

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import CampaignProgressBar from './CampaignProgressBar';
 import styled from 'styled-components';
 import {
-  tabletScreens, desktopScreens
+  tabletScreens
 } from '../../../utilities/general/responsive';
 import campaignDefaultImage from '../images/campaign_default.png';
 import { Campaign } from '../../../utilities/api/types';
@@ -215,14 +215,12 @@ const ImagesContainer = styled.span`
 `;
 
 const CampaignImage = styled.img`
+  height: 240px;
+  width: 240px;
+
   @media (${tabletScreens}) {
     max-height: 100px;
     width: 100%;
-  }
-
-  @media (${desktopScreens}) {
-    max-height: 240px;
-    max-width: 240px;
   }
 `;
 


### PR DESCRIPTION
The `desktopScreens` media query was failing to shrink large images properly, so removing it.

Desktop
<img width="735" alt="Screen Shot 2020-08-14 at 12 00 16 AM" src="https://user-images.githubusercontent.com/2313868/90304486-72ba0900-de86-11ea-9e66-f7aca72bebda.png">

Mobile
<img width="426" alt="Screen Shot 2020-08-14 at 11 29 25 PM" src="https://user-images.githubusercontent.com/2313868/90304488-764d9000-de86-11ea-9042-31335cb2bff4.png">
