### PR TITLE
Wire up GAM highlight box to new GAM page

### DIFF
--- a/src/components/MerchantsPage/GiftMealHighlightBox.tsx
+++ b/src/components/MerchantsPage/GiftMealHighlightBox.tsx
@@ -14,7 +14,7 @@ const GiftMealHighlightBox = () => {
 
   const onButtonClick = (e: any) => {
     ReactPixel.trackCustom('GiftMealBoxButtonClick', {});
-    // TODO: Add router to open GAM page
+    window.location.href = '/gift-a-meal-home';
   };
 
   return (


### PR DESCRIPTION
Note: The highlight box won't be added to the Merchant's page until the new GAM page is 100% ready and tested.

Test plan:
![gam-launch](https://user-images.githubusercontent.com/2313868/90846480-3da23080-e336-11ea-82d1-4ad1716d73b2.gif)
