### PR TITLE
fixed multiple modals on gam home page

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -15,6 +15,8 @@ import { SET_MODAL_VIEW } from '../../../utilities/hooks/ModalPaymentContext/con
 
 interface Props {
   campaign: Campaign;
+  selectedCampaign: null | number,
+  setSelectedCampaign: Function
 }
 
 const ModalBox: any = Modal;
@@ -44,6 +46,7 @@ const CampaignListItem = (props: Props) => {
 
   const dispatch = useModalPaymentDispatch(); //provide null according to Bruce's new branch
   const showModal = (event: any) => {
+    props.setSelectedCampaign(campaign.id)
     dispatch({ type: SET_MODAL_VIEW, payload: 0 });
   };
 
@@ -100,7 +103,7 @@ const CampaignListItem = (props: Props) => {
         )}
       </ColumnContainer>
 
-      {merchant && (
+      {campaign.active && props.selectedCampaign === campaign.id && (
         <ModalBox
           purchaseType={'buy_meal'}
           sellerId={merchant.seller_id}

--- a/src/components/MerchantsPage/gam/GiftAMealPage.tsx
+++ b/src/components/MerchantsPage/gam/GiftAMealPage.tsx
@@ -17,6 +17,7 @@ const GiftAMealPage = (props: Props) => {
 
   const [activeCampaigns, setActiveCampaigns] = useState([]);
   const [pastCampaigns, setPastCampaigns] = useState([]);
+  const [selectedCampaign, setSelectedCampaign] = useState(null)
 
   const fetchData = async () => {
     const campaignData = await getCampaigns();
@@ -64,7 +65,12 @@ const GiftAMealPage = (props: Props) => {
         ? <>
           <h5 className={styles.campaignHeader}>{t('gamHome.activeSection')}</h5>
           {activeCampaigns.map((campaign: any) => (
-            <CampaignListItem campaign={campaign} key={campaign.id} />
+            <CampaignListItem
+              campaign={campaign}
+              key={campaign.id}
+              selectedCampaign={selectedCampaign}
+              setSelectedCampaign={setSelectedCampaign}
+            />
           ))}
         </>
         : <NoActiveCampaignsBox />
@@ -77,7 +83,12 @@ const GiftAMealPage = (props: Props) => {
 
       <h5 className={styles.campaignHeader}>{t('gamHome.pastSection')}</h5>
       {pastCampaigns.map((campaign: any) => (
-        <CampaignListItem campaign={campaign} key={campaign.id} />
+        <CampaignListItem
+          campaign={campaign}
+          key={campaign.id}
+          selectedCampaign={selectedCampaign}
+          setSelectedCampaign={setSelectedCampaign}
+        />
       ))}
     </div >
   );


### PR DESCRIPTION
Added local state to prevent multiple modals from rendering and opening at once. GIF below demos correct modal opening.


![ScreenRecording](https://user-images.githubusercontent.com/10109538/90946033-20816680-e3f7-11ea-836b-30aa02ce41e4.gif)

Also the SquareCardForm is back:
<img width="812" alt="Screen Shot 2020-08-21 at 9 54 53 PM" src="https://user-images.githubusercontent.com/10109538/90946250-021c6a80-e3f9-11ea-95f8-af74a2cd7d52.png">

