### PR TITLE
Make entire highlight box clickable on mobile screen sizes

### DIFF
--- a/src/components/MerchantsPage/DonationHighlightBox.tsx
+++ b/src/components/MerchantsPage/DonationHighlightBox.tsx
@@ -7,6 +7,7 @@ import { getWebsiteImages } from '../../utilities/general/StoreImages';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import ReactPixel from 'react-facebook-pixel';
+import { useWindowSize } from '../../utilities/hooks/helpers'
 
 const DonationHighlightBox = () => {
   const websiteImages = getWebsiteImages();
@@ -19,8 +20,12 @@ const DonationHighlightBox = () => {
     dispatch({ type: SET_MODAL_VIEW, payload: 0 });
   };
 
+  const containerClickHandler = useWindowSize().width < 600
+    ? openModal
+    : () => {};
+
   return (
-    <Container>
+    <Container onClick={containerClickHandler}>
       <Image src={websiteImages.donationPoolHero} alt="banner" />
 
       <ColumnContainer>

--- a/src/components/MerchantsPage/GiftMealHighlightBox.tsx
+++ b/src/components/MerchantsPage/GiftMealHighlightBox.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import Modal from '../Modal';
-import { SET_MODAL_VIEW } from '../../utilities/hooks/ModalPaymentContext/constants';
-import { useModalPaymentDispatch } from '../../utilities/hooks/ModalPaymentContext/context';
 import { smallScreens } from '../../utilities/general/responsive';
 import { getWebsiteImages } from '../../utilities/general/StoreImages';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import ReactPixel from 'react-facebook-pixel';
+import { useWindowSize } from '../../utilities/hooks/helpers'
 
 const GiftMealHighlightBox = () => {
   const websiteImages = getWebsiteImages();
@@ -17,8 +15,12 @@ const GiftMealHighlightBox = () => {
     window.location.href = '/gift-a-meal-home';
   };
 
+  const containerClickHandler = useWindowSize().width < 600
+    ? onButtonClick
+    : () => {};
+
   return (
-    <Container>
+    <Container onClick={containerClickHandler}>
       <Image src={websiteImages.gamHero} alt="banner" />
 
       <ColumnContainer>

--- a/src/utilities/hooks/helpers.ts
+++ b/src/utilities/hooks/helpers.ts
@@ -1,4 +1,5 @@
 import { LocationInfo } from '../../utilities/hooks/VoucherContext/types';
+import { useState, useEffect } from 'react';
 
 export const getLocationInfo = (merchantData): LocationInfo => {
   const emptyLocationInfo = {
@@ -20,4 +21,28 @@ export const getLocationInfo = (merchantData): LocationInfo => {
     }`,
   };
   return locationInfo;
+};
+
+ // https://usehooks.com/useWindowSize/
+ export const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowSize;
 };


### PR DESCRIPTION
The CTA buttons for the new pool donation and GAM boxes are hidden on mobile browsers, so we need to make the entire box tappable

Test plan:
![highlight-box](https://user-images.githubusercontent.com/2313868/90963852-64bd4700-e489-11ea-8f0d-6b47ce187ad1.gif)
