### PR TITLE
Fixed bug when calling seller's campaign endpoint

### DIFF
--- a/src/components/OwnerPanel/OwnerPanel.tsx
+++ b/src/components/OwnerPanel/OwnerPanel.tsx
@@ -30,8 +30,8 @@ const OwnerPanel = ({ seller }: Props) => {
   const [purchaseType, setPurchaseType] = useState('');
   const [activeCampaign, setActiveCampaign] = useState<any | null>();
 
-  const fetchData = async () => {
-    const campaigns = await getCampaignsForMerchant(seller.seller_id);
+  const fetchData = async (seller_id: string) => {
+    const campaigns = await getCampaignsForMerchant(seller_id);
     if (campaigns.data) {
       const active = campaigns.data.find(
         (campaign: any) => campaign.active
@@ -42,7 +42,9 @@ const OwnerPanel = ({ seller }: Props) => {
   };
 
   useEffect(() => {
-    fetchData();
+    if (seller.seller_id) {
+      fetchData(seller.seller_id);
+    }
     // eslint-disable-next-line
   }, []);
 


### PR DESCRIPTION
The initial implementation was making two HTTP requests, one of which had a null `seller_id`, and fails. This removes the duplicate request

Before:
<img width="483" alt="Screen Shot 2020-08-24 at 8 08 37 PM" src="https://user-images.githubusercontent.com/2313868/91108579-58321d80-e646-11ea-8e6e-7315e219f7fe.png">

After:
<img width="542" alt="Screen Shot 2020-08-24 at 8 10 00 PM" src="https://user-images.githubusercontent.com/2313868/91108575-55372d00-e646-11ea-89b1-8764b0301e7c.png">

