### PR TITLE
Make distributor link in-line with description to save space

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -66,7 +66,7 @@ const CampaignListItem = (props: Props) => {
         )}
         <Description>
           {campaign.description}
-          <br></br>
+          {' '}
           {distributor &&
             (<a href={distributor.website_url}>{distributor.name}</a>)
           }


### PR DESCRIPTION
Saves vertical space so we can include longer descriptions

Test plan
<img width="573" alt="Screen Shot 2020-08-24 at 8 26 23 PM" src="https://user-images.githubusercontent.com/2313868/91113442-984bcd00-e653-11ea-8e68-39ec4a061131.png">


