### PR TITLE
Olivia/passport redemption fixes 1

### DIFF
--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -12,7 +12,7 @@ import {
   getPassportTickets,
   getOneSponsor,
   getLocationById,
-  redeemReward
+  redeemReward,
 } from '../../utilities/api/interactionManager';
 
 interface Props {
@@ -35,7 +35,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
     },
     logo_url: '',
     reward: '',
-    reward_detail: ''
+    reward_detail: '',
   });
 
   const fetchSponsor = async () => {
@@ -58,19 +58,15 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
         .filter((ticket) => ticket.sponsor_seller_id === null)
         .slice(0, 3)
         .map((ticket) => {
-          return { id: ticket.id, sponsor_seller_id }
-        })
-      const { status } = await redeemReward(
-        id,
-        access_token,
-        ticketsToRedeem
-      );
+          return { id: ticket.id, sponsor_seller_id };
+        });
+      const { status } = await redeemReward(id, access_token, ticketsToRedeem);
       // add some kind of error handling to redirect user here
-      if (status !== 200) push(`/passport/${id}/tickets`)
+      if (status !== 200) push(`/passport/${id}/tickets`);
     } catch (err) {
       console.error('passport error: ' + err);
     }
-  }
+  };
 
   useEffect(() => {
     fetchSponsor();
@@ -113,8 +109,10 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
               {selectedReward && selectedReward.location && (
                 <>
                   <Text className="finePrint">
-                    {selectedReward.location.address1}{selectedReward.location.address2 && ', '}
-                    {selectedReward.location.address2 && selectedReward.location.address2}
+                    {selectedReward.location.address1}
+                    {selectedReward.location.address2 && ', '}
+                    {selectedReward.location.address2 &&
+                      selectedReward.location.address2}
                   </Text>
                 </>
               )}
@@ -139,8 +137,8 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
           value="redemption-selected-button"
           className="button--red-filled"
           onClick={(e) => {
-            e.preventDefault()
-            window.location.href = `/passport/${id}/redeem/${access_token}`
+            e.preventDefault();
+            window.location.href = `/passport/${id}/redeem/${access_token}`;
           }}
         >
           MARK AS USED
@@ -194,7 +192,7 @@ const Text = styled.p`
     font-size: 14px;
     margin-bottom: 5px;
   }
-  
+
   &.subheader {
     font-size: 10px;
     margin-bottom: 15px;

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -111,13 +111,8 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
               {selectedReward && selectedReward.location && (
                 <>
                   <Text className="finePrint">
-                    {selectedReward.location.address1},{' '}
-                    {selectedReward.location.address2}
-                  </Text>
-                  <Text className="finePrint">
-                    {selectedReward.location.city},{' '}
-                    {selectedReward.location.state}{' '}
-                    {selectedReward.location.zip_code}
+                    {selectedReward.location.address1}{selectedReward.location.address2 && ', '}
+                    {selectedReward.location.address2 && selectedReward.location.address2}
                   </Text>
                 </>
               )}
@@ -190,7 +185,7 @@ const Text = styled.p`
   letter-spacing: 0.1em;
   font-weight: bold;
   font-size: 15px;
-  line-height: 75%;
+  line-height: 100%;
   text-align: center;
 
   &.header {

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -25,7 +25,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
     location: {
       address1: '',
       address2: '',
-      borough: '',
+      city: '',
       state: '',
       zip_code: '',
     },
@@ -33,13 +33,13 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
     reward: '',
   });
 
-  const fetchData = async () => {
+  const fetchSponsor = async () => {
     try {
-      const sponsorResponse = await getOneSponsor(sponsor_seller_id);
-      const locationResponse = await getLocationById(sponsorResponse.data.id);
+      const { data: sponsor } = await getOneSponsor(sponsor_seller_id);
+      const { data: location } = await getLocationById(sponsor.data.id);
       setSelectedReward({
-        ...sponsorResponse.data,
-        location: locationResponse.data,
+        ...sponsor,
+        location: location,
       });
     } catch (error) {
       console.error('passport error: ' + error);
@@ -47,7 +47,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
   };
 
   useEffect(() => {
-    fetchData();
+    fetchSponsor();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -89,7 +89,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
                     {selectedReward.location.address2}
                   </Text>
                   <Text className="finePrint">
-                    {selectedReward.location.borough},{' '}
+                    {selectedReward.location.city},{' '}
                     {selectedReward.location.state}{' '}
                     {selectedReward.location.zip_code}
                   </Text>

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 
 import { InputContainer } from './TrackScreen';
 import { Button, SubTitle } from './style';
@@ -20,6 +20,7 @@ interface Props {
 }
 
 const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
+  const { push } = useHistory();
   const { id, access_token, sponsor_seller_id } = useParams();
 
   const [selectedReward, setSelectedReward] = useState({
@@ -64,6 +65,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
         ticketsToRedeem
       );
       // add some kind of error handling to redirect user here
+      if (status !== 200) push(`/passport/${id}/tickets`)
     } catch (err) {
       console.error('passport error: ' + err);
     }
@@ -139,7 +141,10 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
         <Button
           value="redemption-selected-button"
           className="button--red-filled"
-          onClick={() => setCurrentScreenView(ScreenName.Redemption)}
+          onClick={(e) => {
+            e.preventDefault()
+            window.location.href = `/passport/${id}/redeem/${access_token}`
+          }}
         >
           MARK AS USED
         </Button>

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -35,6 +35,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
     },
     logo_url: '',
     reward: '',
+    reward_detail: ''
   });
 
   const fetchSponsor = async () => {
@@ -104,6 +105,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
         <InputContainer className="top shadow">
           <Content>
             <Text className="header">{selectedReward.reward}</Text>
+            <Text className="subheader">{selectedReward.reward_detail}</Text>
             <img src={'logo_url'} alt="reward-logo" width="260px" />
             <br />
             <div>
@@ -189,7 +191,13 @@ const Text = styled.p`
   text-align: center;
 
   &.header {
-    font-size: 30px;
+    font-size: 14px;
+    margin-bottom: 5px;
+  }
+  
+  &.subheader {
+    font-size: 10px;
+    margin-bottom: 15px;
   }
 
   &.finePrint {

--- a/src/pages/PassportRedemption/RedemptionFooters.tsx
+++ b/src/pages/PassportRedemption/RedemptionFooters.tsx
@@ -2,13 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { SubTitle, Button } from './style';
-import ScreenName from './ScreenName';
 
-interface NoRewardsProps {
-  setCurrentScreenView: Function;
-}
+export const NoRewardsFooter = () => {
 
-export const NoRewardsFooter = (props: NoRewardsProps) => {
   return (
     <Footer>
       <SubTitle bold="700">Have more tickets to add?</SubTitle>
@@ -16,7 +12,10 @@ export const NoRewardsFooter = (props: NoRewardsProps) => {
       <Button
         value="redemption-selected-button"
         className="button--red-filled"
-        onClick={() => props.setCurrentScreenView(ScreenName.Track)}
+        onClick={(e) => {
+          e.preventDefault()
+          window.location.href = '/passport'
+        }}
       >
         ADD NEW TICKETS
       </Button>
@@ -25,10 +24,13 @@ export const NoRewardsFooter = (props: NoRewardsProps) => {
 };
 
 interface RedeemRewardsProps {
+  id: number,
+  access_token: string,
   selectedSponsor: null | any;
 }
 
 export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
+
   return (
     <Footer>
       <SubTitle bold="700">
@@ -39,7 +41,10 @@ export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
         value="redemption-selected-button"
         className="button--red-filled"
         disabled={!props.selectedSponsor}
-        onClick={() => {}}
+        onClick={(e) => {
+          e.preventDefault()
+          window.location.href = `/passport/${props.id}/redeem/${props.access_token}/sponsor/${props.selectedSponsor.id}`
+        }}
       >
         REEDEM NOW
       </Button>
@@ -53,6 +58,7 @@ interface defaultProps {
 }
 
 export const DefaultFooter = (props: defaultProps) => {
+
   return (
     <Footer>
       <SubTitle bold="700">
@@ -64,7 +70,7 @@ export const DefaultFooter = (props: defaultProps) => {
           className="linkButton"
           onClick={(e) => {
             e.preventDefault();
-            window.location.href = `/passport/${props.id}`;
+            window.location.href = `/passport/${props.id}/tickets`;
           }}
         >
           RETURN TO PASSPORT

--- a/src/pages/PassportRedemption/RedemptionFooters.tsx
+++ b/src/pages/PassportRedemption/RedemptionFooters.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { SubTitle, Button } from './style';
 
 export const NoRewardsFooter = () => {
-
   return (
     <Footer>
       <SubTitle bold="700">Have more tickets to add?</SubTitle>
@@ -13,8 +12,8 @@ export const NoRewardsFooter = () => {
         value="redemption-selected-button"
         className="button--red-filled"
         onClick={(e) => {
-          e.preventDefault()
-          window.location.href = '/passport'
+          e.preventDefault();
+          window.location.href = '/passport';
         }}
       >
         ADD NEW TICKETS
@@ -24,17 +23,16 @@ export const NoRewardsFooter = () => {
 };
 
 interface RedeemRewardsProps {
-  id: number,
-  access_token: string,
+  id: number;
+  access_token: string;
   selectedSponsor: null | any;
 }
 
 export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
-
   return (
     <Footer>
       <SubTitle bold="700">
-          When redeemed, you have 5 minutes to use your reward.
+        When redeemed, you have 5 minutes to use your reward.
       </SubTitle>
 
       <Button
@@ -42,8 +40,8 @@ export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
         className="button--red-filled"
         disabled={!props.selectedSponsor}
         onClick={(e) => {
-          e.preventDefault()
-          window.location.href = `/passport/${props.id}/redeem/${props.access_token}/sponsor/${props.selectedSponsor.id}`
+          e.preventDefault();
+          window.location.href = `/passport/${props.id}/redeem/${props.access_token}/sponsor/${props.selectedSponsor.id}`;
         }}
       >
         REEDEM NOW
@@ -58,7 +56,6 @@ interface defaultProps {
 }
 
 export const DefaultFooter = (props: defaultProps) => {
-
   return (
     <Footer>
       <SubTitle bold="700">

--- a/src/pages/PassportRedemption/RedemptionFooters.tsx
+++ b/src/pages/PassportRedemption/RedemptionFooters.tsx
@@ -25,25 +25,21 @@ export const NoRewardsFooter = (props: NoRewardsProps) => {
 };
 
 interface RedeemRewardsProps {
-  error: string;
   selectedSponsor: null | any;
-  handleRedemption: Function;
 }
 
 export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
   return (
     <Footer>
       <SubTitle bold="700">
-        {props.error
-          ? props.error
-          : 'When redeemed, you have 5 minutes to use your reward.'}
+          When redeemed, you have 5 minutes to use your reward.
       </SubTitle>
 
       <Button
         value="redemption-selected-button"
         className="button--red-filled"
         disabled={!props.selectedSponsor}
-        onClick={() => props.handleRedemption()}
+        onClick={() => {}}
       >
         REEDEM NOW
       </Button>

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -57,20 +57,25 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
     } catch (err) {
       console.error('passport error: ' + err);
     }
-  }
+  };
 
   useEffect(() => {
     fetchTickets();
     fetchSponsors();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleFooter = () => {
-    if (numRewards === 0)
-      return <NoRewardsFooter  />;
+    if (numRewards === 0) return <NoRewardsFooter />;
     else if (!!selectedSponsor.id)
-      return <RedeemRewardsFooter id={id} access_token={access_token} selectedSponsor={selectedSponsor} />;
+      return (
+        <RedeemRewardsFooter
+          id={id}
+          access_token={access_token}
+          selectedSponsor={selectedSponsor}
+        />
+      );
     else return <DefaultFooter allSponsors={allSponsors} id={id} />;
   };
 

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -13,7 +13,6 @@ import {
   getPassportTickets,
   getAllSponsors,
   getLocationById,
-  redeemReward,
 } from '../../utilities/api/interactionManager';
 
 interface Props {
@@ -24,9 +23,9 @@ interface Props {
 const PassportSelected = ({ setCurrentScreenView }: Props) => {
   const { id, access_token } = useParams();
 
-  const [error, setError] = useState('');
   const [tickets, setTickets] = useState<any[]>([]);
   const numRewards = Math.floor(tickets.length / 3);
+  
   const [allSponsors, setAllSponsors] = useState<any[]>([]);
   const [selectedSponsor, setSelectedSponsor] = useState({
     id: null,
@@ -67,36 +66,11 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleRedemption = async () => {
-    try {
-      const ticketsToRedeem = tickets.slice(0, 3).map((ticket) => {
-        return { id: ticket.id, sponsor_seller_id: selectedSponsor.id };
-      });
-      const redemptionResponse = await redeemReward(
-        id,
-        access_token,
-        ticketsToRedeem
-      );
-      // TODO OS: so this isn't very secure, right? instead of route, should I just change view to RedemptionClaimScreen?
-      if (redemptionResponse.status === 200) {
-        window.location.href = `/passport/${id}/redeem/${access_token}/sponsor/${selectedSponsor.id}`;
-      } else setError('Something went wrong! Please try again.');
-    } catch (err) {
-      console.error('passport error: ' + err);
-    }
-  };
-
   const handleFooter = () => {
     if (numRewards === 0)
       return <NoRewardsFooter setCurrentScreenView={setCurrentScreenView} />;
     else if (!!selectedSponsor.id)
-      return (
-        <RedeemRewardsFooter
-          error={error}
-          selectedSponsor={selectedSponsor}
-          handleRedemption={handleRedemption}
-        />
-      );
+      return <RedeemRewardsFooter selectedSponsor={selectedSponsor} />;
     else return <DefaultFooter allSponsors={allSponsors} id={id} />;
   };
 

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -33,28 +33,36 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
     reward_cost: null,
   });
 
-  const fetchData = async () => {
+  const fetchTickets = async () => {
     try {
-      const ticketsResponse = await getPassportTickets(id);
-      const availableTickets = ticketsResponse.data.filter(
+      const { data: allTickets } = await getPassportTickets(id);
+      const availableTickets = allTickets.filter(
         (ticket) => ticket.sponsor_seller_id === null
       );
       setTickets(availableTickets);
-      const allSponsorsResponse = await getAllSponsors();
+    } catch (err) {
+      console.error('passport error: ' + err);
+    }
+  };
+
+  const fetchSponsors = async () => {
+    try {
+      const { data: allSponsors } = await getAllSponsors();
       const allSponsorsWithLocations = await Promise.all(
-        allSponsorsResponse.data.map(async (sponsor) => {
-          const locationResponse = await getLocationById(sponsor.location_id);
-          return { ...sponsor, location: locationResponse.data };
+        allSponsors.map(async (sponsor) => {
+          const { data: location } = await getLocationById(sponsor.location_id);
+          return { ...sponsor, location: location };
         })
       );
       setAllSponsors(allSponsorsWithLocations);
     } catch (err) {
       console.error('passport error: ' + err);
     }
-  };
+  }
 
   useEffect(() => {
-    fetchData();
+    fetchTickets();
+    fetchSponsors();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -25,7 +25,7 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
 
   const [tickets, setTickets] = useState<any[]>([]);
   const numRewards = Math.floor(tickets.length / 3);
-  
+
   const [allSponsors, setAllSponsors] = useState<any[]>([]);
   const [selectedSponsor, setSelectedSponsor] = useState({
     id: null,
@@ -68,9 +68,9 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
 
   const handleFooter = () => {
     if (numRewards === 0)
-      return <NoRewardsFooter setCurrentScreenView={setCurrentScreenView} />;
+      return <NoRewardsFooter  />;
     else if (!!selectedSponsor.id)
-      return <RedeemRewardsFooter selectedSponsor={selectedSponsor} />;
+      return <RedeemRewardsFooter id={id} access_token={access_token} selectedSponsor={selectedSponsor} />;
     else return <DefaultFooter allSponsors={allSponsors} id={id} />;
   };
 


### PR DESCRIPTION
**What I Did:**
- cleaned up all code for API calls on `Select` and `Claim` screens
- moved `PUT /tickets/:ticket_id` call to `Claim` screen and added some error handling so that if the response status is not 200, the user is rerouted to Passport screen
- double checked all of the routing
- removed `sponsor_seller` city, borough, state, zip data from address on `Claim` screen
- added some conditional logic to manage `sponsor_seller` address2 on `Claim` screen
- fixed the reward and reward_detail styling on `Claim` screen

**Screencap:**
<img width="360" alt="Screen Shot 2020-08-27 at 6 43 38 PM" src="https://user-images.githubusercontent.com/10109538/91502538-5068b800-e896-11ea-9242-daa38347fa4a.png">
