### PR TITLE
olivia/passport redemption fixes 2

### DIFF
--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -61,7 +61,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
           return { id: ticket.id, sponsor_seller_id };
         });
       const { status } = await redeemReward(id, access_token, ticketsToRedeem);
-      // add some kind of error handling to redirect user here
+      // figure out how to handle invalid redemption with this page
       if (status !== 200) push(`/passport/${id}/tickets`);
     } catch (err) {
       console.error('passport error: ' + err);

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -35,7 +35,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
     },
     logo_url: '',
     reward: '',
-    reward_detail: '',
+    reward_detail: ''
   });
 
   const fetchSponsor = async () => {
@@ -193,9 +193,9 @@ const Text = styled.p`
     margin-bottom: 5px;
   }
 
-  &.subheader {
-    font-size: 10px;
-    margin-bottom: 15px;
+  &.subheader {	
+    font-size: 10px;	
+    margin-bottom: 15px;	
   }
 
   &.finePrint {

--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -102,7 +102,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
           <Content>
             <Text className="header">{selectedReward.reward}</Text>
             <Text className="subheader">{selectedReward.reward_detail}</Text>
-            <img src={'logo_url'} alt="reward-logo" width="260px" />
+            <img src={selectedReward.logo_url} alt="reward-logo" width="260px" />
             <br />
             <div>
               <Text className="">{selectedReward.name}</Text>

--- a/src/pages/PassportRedemption/RedemptionFooters.tsx
+++ b/src/pages/PassportRedemption/RedemptionFooters.tsx
@@ -44,7 +44,7 @@ export const RedeemRewardsFooter = (props: RedeemRewardsProps) => {
           window.location.href = `/passport/${props.id}/redeem/${props.access_token}/sponsor/${props.selectedSponsor.id}`;
         }}
       >
-        REEDEM NOW
+        REDEEM NOW
       </Button>
     </Footer>
   );

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -19,7 +19,6 @@ interface Props {
   setCurrentScreenView: Function;
 }
 
-// TODO: Ask design --> do we want user to be able to unselect a reward?
 const PassportSelected = ({ setCurrentScreenView }: Props) => {
   const { id, access_token } = useParams();
 
@@ -99,11 +98,17 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
               <SingleRewardContainer
                 className={selectedSponsor.id === id ? 'selected' : ''}
                 onClick={() => {
-                  if (numRewards > 0)
+                  if (selectedSponsor.id !== sponsor.id) {
                     setSelectedSponsor({
                       id: sponsor.id,
                       reward_cost: sponsor.reward_cost,
                     });
+                  } else {
+                    setSelectedSponsor({
+                      id: null,
+                      reward_cost: null,
+                    });
+                  }
                 }}
               >
                 {numRewards !== 0 &&

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -106,11 +106,13 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
                     });
                 }}
               >
-                <input
-                  type="radio"
-                  checked={selectedSponsor.id === sponsor.id}
-                  id={sponsor.reward}
-                />
+                {numRewards !== 0 &&
+                  <input
+                    type="radio"
+                    checked={selectedSponsor.id === sponsor.id}
+                    id={sponsor.reward}
+                  />
+                }
 
                 <SingleRewardInfo>
                   <Text className="header">{sponsor.reward}</Text>

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -53,7 +53,6 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
         })
       );
       setAllSponsors(allSponsorsWithLocations);
-      console.log(allSponsorsWithLocations)
     } catch (err) {
       console.error('passport error: ' + err);
     }

--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -54,6 +54,7 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
         })
       );
       setAllSponsors(allSponsorsWithLocations);
+      console.log(allSponsorsWithLocations)
     } catch (err) {
       console.error('passport error: ' + err);
     }
@@ -113,6 +114,7 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
 
                 <SingleRewardInfo>
                   <Text className="header">{sponsor.reward}</Text>
+                  <Text className="header">{sponsor.reward_detail}</Text>
                   <img
                     src={sponsor.logo_url}
                     alt="reward-logo"


### PR DESCRIPTION
I batched up a couple of smaller bug fixes here, but they each have their own commit.

**Summary of Fixes:**
- the `Claim Screen` now references the `logo_url`, not a placeholder
- I fixed the REEDEM NOW typo on the `Select Screen` screen
- <s>I removed the `reward_detail` from the `Claim Screen` and moved it to the `Select Screen`</s>
- I added `reward_detail` to the `Select Screen`
- I hid radio buttons on the `Select Screen` when the user has zero rewards available
- I enabled deselecting rewards by clicking again on a select reward, but I will check in with Nanxi to see if she wants to implement this differently