### PR TITLE
Fixed bug where tooltip hides too early

### DIFF
--- a/src/pages/PassportRedemption/TrackScreen.tsx
+++ b/src/pages/PassportRedemption/TrackScreen.tsx
@@ -93,7 +93,6 @@ const Track = ({ setCurrentScreenView }: Props) => {
       width: '100%',
       fontSize: theme.typography.pxToRem(14),
       border: '1px solid #dadde9',
-      leaveTouchDelay: '60000'
     },
   }))(Tooltip);
 
@@ -191,6 +190,7 @@ const Track = ({ setCurrentScreenView }: Props) => {
                   </React.Fragment>
                 }
                 enterTouchDelay={10}
+                leaveTouchDelay={6000}
                 placement="left"
               >
                 <div>
@@ -225,11 +225,11 @@ const Track = ({ setCurrentScreenView }: Props) => {
           {
             !!email && EMAIL_REGEX.test(email) && (
               <Button
-              className="linkButton"
-              disabled={!email}
-              onClick={() => {
-                findOrCreateUser(email, true);
-              }}
+                className="linkButton"
+                disabled={!email}
+                onClick={() => {
+                  findOrCreateUser(email, true);
+                }}
               >
                 View my tickets
               </Button>


### PR DESCRIPTION
The IG tooltip was hiding after 1.5 seconds, which is too little time to read.

Before:
![tooltip-delay-bug](https://user-images.githubusercontent.com/2313868/91645431-f93c2200-ea12-11ea-921d-00090b0a995b.gif)

After:
![tooltip-delay](https://user-images.githubusercontent.com/2313868/91645433-fe00d600-ea12-11ea-99af-5aa97dd51863.gif)
