### PR TITLE
Fixed bugs in rewards redemption screen

### DIFF
--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -97,6 +97,9 @@ const PassportSelected = ({ setCurrentScreenView }: Props) => {
               <SingleRewardContainer
                 className={selectedSponsor.id === id ? 'selected' : ''}
                 onClick={() => {
+                  if (numRewards === 0) {
+                    return;
+                  }
                   if (selectedSponsor.id !== sponsor.id) {
                     setSelectedSponsor({
                       id: sponsor.id,
@@ -193,6 +196,7 @@ const RewardsContainer = styled.div<{
       : '575px'};
   overflow-y: scroll;
   padding-top: 20px;
+  padding-bottom: 30px;
 
   ::-webkit-scrollbar {
     width: 0px;
@@ -228,7 +232,7 @@ const RewardsContainer = styled.div<{
 
 const SingleRewardContainer = styled.button`
   width: 160px;
-  height: 220px;
+  height: 250px;
   border: 1px solid #e5e5e5;
   background-color: white;
   padding: 5px 5px;


### PR DESCRIPTION
-Increased SingleRewardContainer height to fit location
-Added bottom padding to RewardsContainer so haze doesn't obscure bottom most reward
-Disable click interaction on the reward container if there are no rewards

Before:
<img width="383" alt="Screen Shot 2020-08-29 at 10 01 08 PM" src="https://user-images.githubusercontent.com/2313868/91649815-f575c300-ea45-11ea-87e4-cf2ffb40d3ea.png"> <img width="384" alt="Screen Shot 2020-08-29 at 10 21 33 PM" src="https://user-images.githubusercontent.com/2313868/91649818-058da280-ea46-11ea-81f8-e8fbad528f0a.png">


After:
<img width="386" alt="Screen Shot 2020-08-29 at 10 14 11 PM" src="https://user-images.githubusercontent.com/2313868/91649823-15a58200-ea46-11ea-962a-6caf484e03a5.png"> <img width="388" alt="Screen Shot 2020-08-29 at 10 14 19 PM" src="https://user-images.githubusercontent.com/2313868/91649856-4ab1d480-ea46-11ea-9891-968920f999db.png">



