### PR TITLE
Fix passport redemption location using sponsor_id instead of location_id

### DIFF
--- a/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionClaimScreen.tsx
@@ -41,7 +41,7 @@ const PassportRedemptionClaim = ({ setCurrentScreenView }: Props) => {
   const fetchSponsor = async () => {
     try {
       const { data: sponsor } = await getOneSponsor(sponsor_seller_id);
-      const { data: location } = await getLocationById(sponsor_seller_id);
+      const { data: location } = await getLocationById(sponsor.location_id);
       setSelectedReward({
         ...sponsor,
         location: location,


### PR DESCRIPTION
Addresses were being displayed incorrectly since the getLocationById was using the sponsor_id instead of the sponsor's location_id. 

I wasn't able to test this locally since I was running into an error while adding a ticket, but I think this should be the fix? 