### PR TITLE
fixed grid properties to show buffer again

### DIFF
--- a/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
+++ b/src/pages/PassportRedemption/RedemptionSelectScreen.tsx
@@ -253,7 +253,6 @@ const Footer = styled.div<{
 const RewardsContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
-  place-items: center;
   overflow-y: scroll;
   padding-top: 20px;
   padding-bottom: 50px;
@@ -284,6 +283,7 @@ const SingleRewardContainer = styled.button<{
   
   display: flex;
   flex-direction: column;
+  place-self: center;
 `;
 
 const SingleRewardInfo = styled.div`


### PR DESCRIPTION
The buffer element wasn't showing up under the reward cards so the last cards were partially hidden by fade again. I changed grid properties to fix this.