### PR TITLE
change font size to 16px in text field

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/src/pages/PassportRedemption/TrackScreen.tsx
+++ b/src/pages/PassportRedemption/TrackScreen.tsx
@@ -334,6 +334,8 @@ const InputField = styled.input`
   border-radius: 5px;
   outline: none;
   -webkit-appearance: none;
+  font-size: 16px;
+  color: grey;
 
   :invalid {
     border: 1px solid red;


### PR DESCRIPTION
**To prevent auto zoom:** 

"The browser will zoom if the font-size is less than 16px and the default font-size for form elements is 11px (at least in Chrome and Safari." 

https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone