### PR TITLE
Updated spacing and alignment in GAM modal

### DIFF
--- a/src/components/ModalBuyMealNew/styles.module.scss
+++ b/src/components/ModalBuyMealNew/styles.module.scss
@@ -1,6 +1,11 @@
 @import '../../index.scss';
 @import '../../responsive';
 
+
+h1 {
+  line-height: 40px;
+}
+
 .amountContainer {
   background-color: #f7f7f7;
   padding: 25px 35px;
@@ -174,6 +179,14 @@
     grid-auto-flow: column;
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(2, 1fr);
+    grid-row-gap: 15px;
+    justify-items: center;
+  }
+
+  @media (max-width: 400px) {
+    grid-auto-flow: column;
+    grid-template-columns: repeat(1, 1fr);
+    grid-template-rows: repeat(4, 1fr);
     grid-row-gap: 15px;
     justify-items: center;
   }


### PR DESCRIPTION
- reduced line height for header text to save vertical space
- make GAM instructions display in a single column if screen size is smaller than 400px

Before:
<img width="358" alt="Screen Shot 2020-09-02 at 11 42 12 PM" src="https://user-images.githubusercontent.com/2313868/92068876-0a1fc700-ed76-11ea-8334-9d786a4675e3.png">

After:
<img width="389" alt="Screen Shot 2020-09-02 at 11 33 14 PM" src="https://user-images.githubusercontent.com/2313868/92068900-1146d500-ed76-11ea-8f1b-6d0348a82338.png">
