### PR TITLE
GAM Campaign List: increase max-height to 800px for desktop

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -137,7 +137,7 @@ export default CampaignListItem;
 const Container = styled.div`
   border-bottom: 1px solid #e5e5e5;
   display: flex;
-  max-height: 350px;
+  max-height: 800px;
   margin: 35px 0 55px;
   justify-content: space-between;
 


### PR DESCRIPTION
Spillage between 900px - to desktop size (e.g. split screen). It is more obvious if campaign description is long. Quick fix - I changed max-height to 800px. Should give ok leeway for long descriptions. Alternative is to increase tablet screen threshold...
**Before:**
![image](https://user-images.githubusercontent.com/37196330/92267871-017ade00-eea7-11ea-8f12-b2cd04e09efc.png)

**After:**
(956 x 850 below)
![image](https://user-images.githubusercontent.com/37196330/92267936-240cf700-eea7-11ea-9876-4bc65f269740.png)
