### PR TITLE
Refactor Lyft css

### DIFF
--- a/src/pages/PassportRedemption/LyftPromo.tsx
+++ b/src/pages/PassportRedemption/LyftPromo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TitleRow, Title, SubTitle, Button } from './style';
+import { TitleRow, SubTitle, Button } from './style';
 import BikeImg from './Citibike_Lyft.png';
 import { useTranslation } from 'react-i18next';
 
@@ -96,30 +96,14 @@ const LyftYesButton = styled(Button)`
   width: 115px;
   margin-right: 8px;
   display: inline-block;
-  align-items: center;
-  justify-content: center;
-  text-transform: uppercase;
+  min-width: 0;
 `;
 
-const LyftNoButton = styled(Button)`
-  padding: 0;
-  text-align: center;
-  height: 33px;
-  width: 115px;
+const LyftNoButton = styled(LyftYesButton)`
   margin-left: 8px;
-  display: inline-block;
-  align-items: center;
-  justify-content: center;
-  text-transform: uppercase;
+  margin-right: 0;
 `;
 
-const LyftCloseButton = styled(Button)`
-  padding: 0;
-  text-align: center;
-  height: 33px;
-  width: 115px;
-  display: inline-block;
-  align-items: center;
-  justify-content: center;
-  text-transform: uppercase;
+const LyftCloseButton = styled(LyftYesButton)`
+  margin: 0;
 `;


### PR DESCRIPTION
Remove duplicate css that is based on the base-button from index.scss as well as same css in the lyft buttons
Min-width - comes from the index.scss which is why the buttons are long
Take it or leave these changes
![claim](https://user-images.githubusercontent.com/37196330/93287606-c2923580-f78e-11ea-828c-3b655606c934.PNG)
![rewards](https://user-images.githubusercontent.com/37196330/93287607-c3c36280-f78e-11ea-9d9f-fbb0015384d7.PNG)
