### PR TITLE
Disable the email modal if the Lyft reward modal is showing

### DIFF
--- a/src/pages/PassportRedemption/Passport.tsx
+++ b/src/pages/PassportRedemption/Passport.tsx
@@ -106,6 +106,10 @@ const Passport = (props: Props) => {
   };
 
   const sendEmail = () => {
+    // Disable the email modal if the Lyft reward modal is showing
+    if (showLyftRewardPromo || lyftRewardConfirmation.showConfirmation) {
+      return;
+    }
     sendRedeemTicketsEmail(id).then((res) => {
       setShowEmailSent(true);
     });


### PR DESCRIPTION
Otherwise the modals will stack on top of eachother

![disable-email-lyft](https://user-images.githubusercontent.com/2313868/93287926-bd41e480-f7a8-11ea-9140-a8d1d853ff4d.gif)
