### PR TITLE
Small GAM clean up

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -36,9 +36,9 @@ const FooterComponent = (props: Props) => {
 
   return (
     <Container theme={theme}>
-      <LogoLink href="https://sendchinatownlove.com/">
+      <a href="https://sendchinatownlove.com/">
         <Logo theme={theme} />
-      </LogoLink>
+      </a>
       <LinksContainer>
         {socialMediaLinks.map((social) => (
           <LinkItem>
@@ -92,10 +92,6 @@ const LinksContainer = styled.div`
   @media (max-width: 599px) {
     flex-direction: row;
   }
-`;
-
-const LogoLink = styled.a`
-  z-index: 5;
 `;
 
 const LinkItem = styled.div`

--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -76,7 +76,7 @@ const CampaignListItem = (props: Props) => {
         <Description>
           {campaign.description}{' '}
           {distributor && (
-            <a href={distributor.website_url}>{distributor.name}</a>
+            <a href={distributor.website_url} target="_blank" rel="noopener noreferrer">Learn more about {distributor.name}.</a>
           )}
         </Description>
         <CampaignProgressBar


### PR DESCRIPTION
- Give more context to the GAM partner link (and open in new tab) after the campaign description.
![image](https://user-images.githubusercontent.com/37196330/93836636-412c1e80-fc38-11ea-8fe5-ebae2802b8cc.png)
- Remove z-index on footer icon since Dan fixed merchant banner overlap some time ago