### PR TITLE
Show all passport stamps

### DIFF
--- a/src/pages/PassportRedemption/TicketRow.tsx
+++ b/src/pages/PassportRedemption/TicketRow.tsx
@@ -81,7 +81,7 @@ const TicketRow = (props: Props) => {
               className="button--red-filled"
               onClick={props.sendEmail}
             >
-              Send to Email
+              Redeem
             </SendEmailButton>
           )}
           <StampRow>{!!props.stamps && createStamps(props.stamps)}</StampRow>
@@ -175,6 +175,7 @@ const SendEmailButton = styled(Button)`
   padding: 0;
   height: 25px;
   width: 300px;
+  top: 65px;
   margin: 0 auto;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
When a person had stamps that were
eligible to be redeemed and they did
not redeem the reward, the passport
stamps are covered by the Send to Email
button.

This created a poor UX, so I moved the
button to the bottom and changed the
text to be "Redeem"


<img width="607" alt="Screen Shot 2020-09-26 at 1 33 34 AM" src="https://user-images.githubusercontent.com/4944733/94331181-51c1f900-ff98-11ea-98f2-8b3285043847.png">
