### PR TITLE
Upgrade @types/react-router-dom to 5.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^12.12.53",
     "@types/react": "^16.9.44",
     "@types/react-dom": "^16.9.0",
-    "@types/react-router-dom": "^5.1.3",
+    "@types/react-router-dom": "^5.1.5",
     "@types/stripe-v3": "^3.1.20",
     "@types/styled-components": "^5.1.2",
     "@types/uuid": "^7.0.4",


### PR DESCRIPTION
Upgrading the react-router-dom typing from 5.1.3 -> 5.1.5 fixed some errors I was getting locally w/ the history typing:
```
  Overload 1 of 2, '(props: Readonly<RouterProps>): Router', gave the following error.
    Type 'History<unknown>' is not assignable to type 'History<PoorMansUnknown>'.
      The types of 'location.state' are incompatible between these types.
        Type 'unknown' is not assignable to type 'PoorMansUnknown'.
          Type 'unknown' is not assignable to type '{}'.
  Overload 2 of 2, '(props: RouterProps, context?: any): Router', gave the following error.
    Type 'History<unknown>' is not assignable to type 'History<PoorMansUnknown>'.  TS2769
    93 | 
    94 |   return (
  > 95 |     <Router history={history}>
       |             ^
    96 |       <Suspense fallback={<Loader isPage={true} />}>
    97 |         <Switch>
    98 |           <Route path="/all">{returnComponent('all')}</Route>
```

Relevant Slack thread: https://send-chinatown-love.slack.com/archives/C012KCW20GM/p1601676265006800