### PR TITLE
Fix console error - add key to social media `LinkItems` in `FooterComponent`

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -41,7 +41,7 @@ const FooterComponent = (props: Props) => {
       </a>
       <LinksContainer>
         {socialMediaLinks.map((social) => (
-          <LinkItem>
+          <LinkItem key={social.platform}>
             <Icon href={social.url} target="_blank">
               <span className={`fa fa-${social.platform}`} />
             </Icon>


### PR DESCRIPTION
Fix the console error (screenshot below) by adding a key to the `LinkItem` in `FooterComponent`

<img width="446" alt="Screen Shot 2020-10-03 at 3 33 27 PM" src="https://user-images.githubusercontent.com/10658691/95002906-fd1d1000-058d-11eb-8eb6-f98b68eb4171.png">