### PR TITLE
Create Page enum for pages (all, seller, merchant, etc.)

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,15 +1,17 @@
 import { createBrowserHistory } from 'history';
-import { Router, Switch, Route, Redirect } from 'react-router-dom';
 import React, { lazy, Suspense, useState } from 'react';
+import ReactPixel from 'react-facebook-pixel';
 import ReactGA from 'react-ga';
+import { Router, Switch, Route, Redirect } from 'react-router-dom';
+
+import Footer from '../Footer';
 import Loader from '../Loader';
 import Header from '../Navbar';
-import Footer from '../Footer';
 import ScrollToTop from '../ScrollToTop';
-import { ModalPaymentProvider } from '../../utilities/hooks/ModalPaymentContext/context';
-import ReactPixel from 'react-facebook-pixel';
-import { VoucherProvider } from '../../utilities/hooks/VoucherContext';
+import { Page } from '../../consts';
 import ScreenName from '../../pages/PassportRedemption/ScreenName';
+import { ModalPaymentProvider } from '../../utilities/hooks/ModalPaymentContext/context';
+import { VoucherProvider } from '../../utilities/hooks/VoucherContext';
 
 const trackingId = process.env.REACT_APP_GA_TRACKING_ID!;
 
@@ -52,33 +54,25 @@ const options = {
 const pixelId = process.env.REACT_APP_FB_PIXEL_ID!;
 ReactPixel.init(pixelId, undefined, options);
 
-enum Pages {
-  ALL = 'ALL',
-  ERROR = 'ERROR',
-  GIFTAMEAL = 'GIFTAMEAL',
-  MERCHANTS = 'MERCHANTS',
-  SELLER = 'SELLER',
-};
-
 const App = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const returnComponent = (child: Pages) => {
+  const returnComponent = (child: Page) => {
     let component;
     switch (child) {
-      case Pages.ALL:
+      case Page.All:
         component = <MerchantsPage menuOpen={menuOpen} />;
         break;
-      case Pages.MERCHANTS:
+      case Page.Merchants:
         component = <Redirect to="/all" />;
         break;
-      case Pages.SELLER:
+      case Page.Seller:
         component = <SellerPage menuOpen={menuOpen} />;
         break;
-      case Pages.GIFTAMEAL:
+      case Page.GiftAMeal:
         component = <GiftAMealPage menuOpen={menuOpen} />;
         break;
-      case Pages.ERROR:
+      case Page.Error:
       default:
         component = <ErrorPage menuOpen={menuOpen} />;
     }
@@ -89,8 +83,8 @@ const App = () => {
           <ScrollToTop />
           <Header
             menuOpen={menuOpen}
-            setMenuOpen={setMenuOpen}
             pageName={child}
+            setMenuOpen={setMenuOpen}
           />
           {component}
           <Footer menuOpen={menuOpen} />
@@ -103,7 +97,7 @@ const App = () => {
     <Router history={history}>
       <Suspense fallback={<Loader isPage={true} />}>
         <Switch>
-          <Route path="/all">{returnComponent(Pages.ALL)}</Route>
+          <Route path="/all">{returnComponent(Page.All)}</Route>
           <Route path="/voucher/:id">
             <VoucherProvider>
               <VoucherRedemptionPage />
@@ -140,11 +134,11 @@ const App = () => {
               return null;
             }}
           />
-          <Route path="/gift-a-meal-home">{returnComponent(Pages.GIFTAMEAL)}</Route>
-          <Route path="/merchants">{returnComponent(Pages.MERCHANTS)}</Route>
-          <Route path="/:id">{returnComponent(Pages.SELLER)}</Route>
-          <Route path="/:id#story">{returnComponent(Pages.SELLER)}</Route>
-          <Route>{returnComponent(Pages.ERROR)}</Route>
+          <Route path="/gift-a-meal-home">{returnComponent(Page.GiftAMeal)}</Route>
+          <Route path="/merchants">{returnComponent(Page.Merchants)}</Route>
+          <Route path="/:id">{returnComponent(Page.Seller)}</Route>
+          <Route path="/:id#story">{returnComponent(Page.Seller)}</Route>
+          <Route>{returnComponent(Page.Error)}</Route>
         </Switch>
       </Suspense>
     </Router>

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -52,27 +52,35 @@ const options = {
 const pixelId = process.env.REACT_APP_FB_PIXEL_ID!;
 ReactPixel.init(pixelId, undefined, options);
 
+enum Pages {
+  ALL = 'ALL',
+  ERROR = 'ERROR',
+  GIFTAMEAL = 'GIFTAMEAL',
+  MERCHANTS = 'MERCHANTS',
+  SELLER = 'SELLER',
+};
+
 const App = () => {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const returnComponent = (child) => {
+  const returnComponent = (child: Pages) => {
     let component;
     switch (child) {
-      case 'all':
+      case Pages.ALL:
         component = <MerchantsPage menuOpen={menuOpen} />;
         break;
-      case 'merchants':
+      case Pages.MERCHANTS:
         component = <Redirect to="/all" />;
         break;
-      case 'seller':
+      case Pages.SELLER:
         component = <SellerPage menuOpen={menuOpen} />;
         break;
-      case 'giftameal':
+      case Pages.GIFTAMEAL:
         component = <GiftAMealPage menuOpen={menuOpen} />;
         break;
+      case Pages.ERROR:
       default:
         component = <ErrorPage menuOpen={menuOpen} />;
-        break;
     }
 
     return (
@@ -95,7 +103,7 @@ const App = () => {
     <Router history={history}>
       <Suspense fallback={<Loader isPage={true} />}>
         <Switch>
-          <Route path="/all">{returnComponent('all')}</Route>
+          <Route path="/all">{returnComponent(Pages.ALL)}</Route>
           <Route path="/voucher/:id">
             <VoucherProvider>
               <VoucherRedemptionPage />
@@ -132,11 +140,11 @@ const App = () => {
               return null;
             }}
           />
-          <Route path="/gift-a-meal-home">{returnComponent('giftameal')}</Route>
-          <Route path="/merchants">{returnComponent('merchants')}</Route>
-          <Route path="/:id">{returnComponent('seller')}</Route>
-          <Route path="/:id#story">{returnComponent('seller')}</Route>
-          <Route>{returnComponent('error')}</Route>
+          <Route path="/gift-a-meal-home">{returnComponent(Pages.GIFTAMEAL)}</Route>
+          <Route path="/merchants">{returnComponent(Pages.MERCHANTS)}</Route>
+          <Route path="/:id">{returnComponent(Pages.SELLER)}</Route>
+          <Route path="/:id#story">{returnComponent(Pages.SELLER)}</Route>
+          <Route>{returnComponent(Pages.ERROR)}</Route>
         </Switch>
       </Suspense>
     </Router>

--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useEffect, MouseEvent } from 'react';
-import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import MenuIcon from '@material-ui/icons/Menu';
 import CloseIcon from '@material-ui/icons/Close';
-import { Logo } from '../Logos';
+import React, { useState, useEffect, MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { Logo } from '../Logos';
+import { Page } from '../../consts'
 
 interface Props {
   menuOpen: boolean;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  pageName: string;
+  pageName: Page;
 }
 
 interface CompactProps {
@@ -38,7 +40,7 @@ const NavBar = (props: Props) => {
     }
   };
 
-  const isMerchantsPathActive = props.pageName === 'all';
+  const isMerchantsPathActive = props.pageName === Page.All;
 
   useEffect(() => {
     if (window.innerWidth < 1025) {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,11 @@
+enum Page {
+  All,
+  Error,
+  GiftAMeal,
+  Merchants,
+  Seller,
+};
+
 const SquareErrors = {
   ADDRESS_VERIFICATION_FAILURE:
     'The card issuer declined the request because the postal code is invalid.',
@@ -56,4 +64,5 @@ const SquareErrors = {
 function hasKey<O>(obj: O, key: keyof any): key is keyof O {
   return key in obj;
 }
-export { SquareErrors, hasKey };
+
+export { Page, SquareErrors, hasKey };


### PR DESCRIPTION
Create Page enum for pages (all, seller, etc.) rather than using strings ('all', 'seller', etc.) for the pages. Also did a bit of alphabetizing and rearranging imports on the files I touched.