### PR TITLE
Add GAM to total contributions bar on all merchants page

### DIFF
--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -52,7 +52,7 @@ const ContributionBar = ({
   let voucherStyle;
   let giftAMealStyle;
   let donationsStyle;
-  console.log(contributionBarProgress)
+  console.log(contributionBarProgress);
   if (isSmallScreen) {
     textContainerStyle = {
       flexDirection: 'column',
@@ -64,8 +64,20 @@ const ContributionBar = ({
     };
     giftAMealStyle = {
       position: 'absolute',
-      right: contributionBarProgress.donationsRaised <= 50 && `${Math.max(contributionBarProgress.donationsRaised + contributionBarProgress.giftAMealAmountRaised / 2, 20)}%`,
-      left: contributionBarProgress.donationsRaised > 50 && `${Math.min(contributionBarProgress.giftCardAmountRaised + contributionBarProgress.giftAMealAmountRaised / 2,80)}%`,
+      right:
+        contributionBarProgress.donationsRaised <= 50 &&
+        `${Math.max(
+          contributionBarProgress.donationsRaised +
+            contributionBarProgress.giftAMealAmountRaised / 2,
+          20
+        )}%`,
+      left:
+        contributionBarProgress.donationsRaised > 50 &&
+        `${Math.min(
+          contributionBarProgress.giftCardAmountRaised +
+            contributionBarProgress.giftAMealAmountRaised / 2,
+          80
+        )}%`,
     };
     donationsStyle = {
       // Keep at least 16px of space between gift-a-meal span and donation span.

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -18,6 +18,21 @@ const ContributionBar = ({
   giftCardAmountRaised,
 }: Props) => {
   const { t } = useTranslation();
+  const [isSmallScreen, setIsSmallScreen] = useState(false);
+
+  const handleResize = useCallback(() => {
+    if (window.innerWidth < 641) {
+      setIsSmallScreen(true);
+    } else {
+      setIsSmallScreen(false);
+    }
+  }, [setIsSmallScreen]);
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [handleResize]);
 
   const totalRaised = useMemo(
     () => donationsRaised + giftAMealAmountRaised + giftCardAmountRaised,
@@ -32,6 +47,31 @@ const ContributionBar = ({
     }),
     [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised, totalRaised],
   );
+
+  let textContainerStyle;
+  let voucherStyle;
+  let giftAMealStyle;
+  let donationsStyle;
+  if (isSmallScreen) {
+    textContainerStyle = {
+      flexDirection: 'column',
+    };
+  } else {
+    voucherStyle = {
+      // Keep at least 16px of space between voucher span and gift-a-meal span.
+      marginRight: '16px',
+    };
+    giftAMealStyle = {
+      position: 'absolute',
+      right: contributionBarProgress.donationsRaised <= 50
+        ? `${Math.max(contributionBarProgress.donationsRaised + (contributionBarProgress.giftAMealAmountRaised / 2), 20)}%`
+        : `${Math.min(contributionBarProgress.donationsRaised - (contributionBarProgress.giftAMealAmountRaised / 2), 80)}%`,
+    };
+    donationsStyle = {
+      // Keep at least 16px of space between gift-a-meal span and donation span.
+      marginLeft: '16px',
+    };
+  }
 
   return (
     <Container>
@@ -58,27 +98,16 @@ const ContributionBar = ({
           )`,
         }}
       />
-      <TextContainer>
-        <ContributionSpan style={{
-          // Keep at least 16px of space between voucher span and gift-a-meal span.
-          marginRight: '16px',
-        }}>
+      <TextContainer style={textContainerStyle}>
+        <ContributionSpan style={voucherStyle}>
             {t('contributionBar.vouchers')}:{' '}
             <b>${(Math.floor(giftCardAmountRaised) / 100).toLocaleString()}</b>
         </ContributionSpan>
-        <ContributionSpan style={{
-          position: 'absolute',
-          right: contributionBarProgress.donationsRaised < 50
-            ? `${contributionBarProgress.donationsRaised + (contributionBarProgress.giftAMealAmountRaised / 2)}%`
-            : `${contributionBarProgress.donationsRaised - (contributionBarProgress.giftAMealAmountRaised / 2)}%`,
-        }}>
+        <ContributionSpan style={giftAMealStyle}>
           {t('contributionBar.giftAMeal')}:{' '}
           <b>${(Math.floor(giftAMealAmountRaised) / 100).toLocaleString()}</b>
         </ContributionSpan>
-        <ContributionSpan style={{
-          // Keep at least 16px of space between gift-a-meal span and donation span.
-          marginLeft: '16px',
-        }}>
+        <ContributionSpan style={donationsStyle}>
           {t('contributionBar.donations')}:{' '}
           <b>${(Math.floor(donationsRaised) / 100).toLocaleString()}</b>
         </ContributionSpan>

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -10,7 +10,7 @@ interface Props {
   giftCardAmountRaised: number;
 }
 
-const percentage = (raised: number, total: number) => raised / total * 100;
+const percentage = (raised: number, total: number) => (raised / total) * 100;
 
 const ContributionBar = ({
   donationsRaised,
@@ -36,7 +36,7 @@ const ContributionBar = ({
 
   const totalRaised = useMemo(
     () => donationsRaised + giftAMealAmountRaised + giftCardAmountRaised,
-    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised],
+    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised]
   );
 
   const contributionBarProgress = useMemo(
@@ -45,7 +45,7 @@ const ContributionBar = ({
       giftAMealAmountRaised: percentage(giftAMealAmountRaised, totalRaised),
       giftCardAmountRaised: percentage(giftCardAmountRaised, totalRaised),
     }),
-    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised, totalRaised],
+    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised, totalRaised]
   );
 
   let textContainerStyle;
@@ -63,9 +63,18 @@ const ContributionBar = ({
     };
     giftAMealStyle = {
       position: 'absolute',
-      right: contributionBarProgress.donationsRaised <= 50
-        ? `${Math.max(contributionBarProgress.donationsRaised + (contributionBarProgress.giftAMealAmountRaised / 2), 20)}%`
-        : `${Math.min(contributionBarProgress.donationsRaised - (contributionBarProgress.giftAMealAmountRaised / 2), 80)}%`,
+      right:
+        contributionBarProgress.donationsRaised <= 50
+          ? `${Math.max(
+              contributionBarProgress.donationsRaised +
+                contributionBarProgress.giftAMealAmountRaised / 2,
+              20
+            )}%`
+          : `${Math.min(
+              contributionBarProgress.donationsRaised -
+                contributionBarProgress.giftAMealAmountRaised / 2,
+              80
+            )}%`,
     };
     donationsStyle = {
       // Keep at least 16px of space between gift-a-meal span and donation span.
@@ -77,7 +86,7 @@ const ContributionBar = ({
     <Container>
       <Heading>
         {t('contributionBar.header')}: $
-        {Math.floor((totalRaised) / 100).toLocaleString()}
+        {Math.floor(totalRaised / 100).toLocaleString()}
       </Heading>
       <Contributions
         style={{
@@ -92,16 +101,22 @@ const ContributionBar = ({
             -45deg,
             #DD678A ${contributionBarProgress.donationsRaised}%,
             #3FD1D1 ${contributionBarProgress.donationsRaised}%,
-            #3FD1D1 ${contributionBarProgress.giftAMealAmountRaised + contributionBarProgress.donationsRaised}%,
-            #F6B917 ${contributionBarProgress.giftAMealAmountRaised + contributionBarProgress.donationsRaised}%,
+            #3FD1D1 ${
+              contributionBarProgress.giftAMealAmountRaised +
+              contributionBarProgress.donationsRaised
+            }%,
+            #F6B917 ${
+              contributionBarProgress.giftAMealAmountRaised +
+              contributionBarProgress.donationsRaised
+            }%,
             #F6B917 0%
           )`,
         }}
       />
       <TextContainer style={textContainerStyle}>
         <ContributionSpan style={voucherStyle}>
-            {t('contributionBar.vouchers')}:{' '}
-            <b>${(Math.floor(giftCardAmountRaised) / 100).toLocaleString()}</b>
+          {t('contributionBar.vouchers')}:{' '}
+          <b>${(Math.floor(giftCardAmountRaised) / 100).toLocaleString()}</b>
         </ContributionSpan>
         <ContributionSpan style={giftAMealStyle}>
           {t('contributionBar.giftAMeal')}:{' '}

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -1,43 +1,87 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
 
+// We assume in this code that all amounts are > 0.
 interface Props {
-  totalDonations: number;
-  totalGiftCards: number;
+  donationsRaised: number;
+  giftAMealAmountRaised: number;
+  giftCardAmountRaised: number;
 }
 
-const ContributionBar = ({ totalDonations, totalGiftCards }: Props) => {
+const percentage = (raised: number, total: number) => raised / total * 100;
+
+const ContributionBar = ({
+  donationsRaised,
+  giftAMealAmountRaised,
+  giftCardAmountRaised,
+}: Props) => {
   const { t } = useTranslation();
 
-  const progressWidth = (raised: number, total: number) => {
-    if (raised < total) return (raised / total) * 100;
-    return 100;
-  };
+  const totalRaised = useMemo(
+    () => donationsRaised + giftAMealAmountRaised + giftCardAmountRaised,
+    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised],
+  );
+
+  const contributionBarProgress = useMemo(
+    () => ({
+      donationsRaised: percentage(donationsRaised, totalRaised),
+      giftAMealAmountRaised: percentage(giftAMealAmountRaised, totalRaised),
+      giftCardAmountRaised: percentage(giftCardAmountRaised, totalRaised),
+    }),
+    [donationsRaised, giftAMealAmountRaised, giftCardAmountRaised, totalRaised],
+  );
 
   return (
     <Container>
       <Heading>
         {t('contributionBar.header')}: $
-        {Math.floor((totalDonations + totalGiftCards) / 100).toLocaleString()}
+        {Math.floor((totalRaised) / 100).toLocaleString()}
       </Heading>
       <Contributions
         style={{
-          background: `linear-gradient(-45deg, #dd678a ${progressWidth(
-            totalDonations,
-            totalDonations + totalGiftCards
-          )}%, #F6B917 0%)`,
+          // Because we want the slash between donation types to be up/right, we need
+          // to make the linear gradient -45deg. Because it's negative degrees,
+          // our donations need to be in reverse order, which is why the donations
+          // are defined first in the css, but appear last in the UI.
+          // See the last paragraph in the section in this site for more info on why
+          // we need to define some of the colors twice:
+          // https://css-tricks.com/css3-gradients/#linear-gradient
+          background: `linear-gradient(
+            -45deg,
+            #DD678A ${contributionBarProgress.donationsRaised}%,
+            #3FD1D1 ${contributionBarProgress.donationsRaised}%,
+            #3FD1D1 ${contributionBarProgress.giftAMealAmountRaised + contributionBarProgress.donationsRaised}%,
+            #F6B917 ${contributionBarProgress.giftAMealAmountRaised + contributionBarProgress.donationsRaised}%,
+            #F6B917 0%
+          )`,
         }}
       />
       <TextContainer>
-        <span>
-          {t('contributionBar.vouchers')}:{' '}
-          <b>${(Math.floor(totalGiftCards) / 100).toLocaleString()}</b>
-        </span>
-        <span>
+        <ContributionSpan style={{
+          // Keep at least 16px of space between voucher span and gift-a-meal span.
+          marginRight: '16px',
+        }}>
+            {t('contributionBar.vouchers')}:{' '}
+            <b>${(Math.floor(giftCardAmountRaised) / 100).toLocaleString()}</b>
+        </ContributionSpan>
+        <ContributionSpan style={{
+          position: 'absolute',
+          right: contributionBarProgress.donationsRaised < 50
+            ? `${contributionBarProgress.donationsRaised + (contributionBarProgress.giftAMealAmountRaised / 2)}%`
+            : `${contributionBarProgress.donationsRaised - (contributionBarProgress.giftAMealAmountRaised / 2)}%`,
+        }}>
+          {t('contributionBar.giftAMeal')}:{' '}
+          <b>${(Math.floor(giftAMealAmountRaised) / 100).toLocaleString()}</b>
+        </ContributionSpan>
+        <ContributionSpan style={{
+          // Keep at least 16px of space between gift-a-meal span and donation span.
+          marginLeft: '16px',
+        }}>
           {t('contributionBar.donations')}:{' '}
-          <b>${(Math.floor(totalDonations) / 100).toLocaleString()}</b>
-        </span>
+          <b>${(Math.floor(donationsRaised) / 100).toLocaleString()}</b>
+        </ContributionSpan>
       </TextContainer>
       <p>{t('contributionBar.footer')}</p>
     </Container>
@@ -62,6 +106,10 @@ const TextContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: space-between;
+`;
+
+const ContributionSpan = styled.span`
+  white-space: nowrap;
 `;
 
 const Heading = styled.div`

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -52,6 +52,7 @@ const ContributionBar = ({
   let voucherStyle;
   let giftAMealStyle;
   let donationsStyle;
+  console.log(contributionBarProgress)
   if (isSmallScreen) {
     textContainerStyle = {
       flexDirection: 'column',
@@ -63,18 +64,8 @@ const ContributionBar = ({
     };
     giftAMealStyle = {
       position: 'absolute',
-      right:
-        contributionBarProgress.donationsRaised <= 50
-          ? `${Math.max(
-              contributionBarProgress.donationsRaised +
-                contributionBarProgress.giftAMealAmountRaised / 2,
-              20
-            )}%`
-          : `${Math.min(
-              contributionBarProgress.donationsRaised -
-                contributionBarProgress.giftAMealAmountRaised / 2,
-              80
-            )}%`,
+      right: contributionBarProgress.donationsRaised <= 50 && `${Math.max(contributionBarProgress.donationsRaised + contributionBarProgress.giftAMealAmountRaised / 2, 20)}%`,
+      left: contributionBarProgress.donationsRaised > 50 && `${Math.min(contributionBarProgress.giftCardAmountRaised + contributionBarProgress.giftAMealAmountRaised / 2,80)}%`,
     };
     donationsStyle = {
       // Keep at least 16px of space between gift-a-meal span and donation span.

--- a/src/components/MerchantsPage/ContributionBar.tsx
+++ b/src/components/MerchantsPage/ContributionBar.tsx
@@ -52,7 +52,6 @@ const ContributionBar = ({
   let voucherStyle;
   let giftAMealStyle;
   let donationsStyle;
-  console.log(contributionBarProgress);
   if (isSmallScreen) {
     textContainerStyle = {
       flexDirection: 'column',

--- a/src/components/MerchantsPage/MerchantsPage.tsx
+++ b/src/components/MerchantsPage/MerchantsPage.tsx
@@ -1,21 +1,36 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { getSellers } from '../../utilities';
-import NavBar from './MerchantNavBar';
-import MerchantCard from './MerchantCard';
-import MerchantDescriptionBanner from './MerchantDescriptionBanner';
+import ReactPixel from 'react-facebook-pixel';
+import { useTranslation } from 'react-i18next';
+
 import ContributionBar from './ContributionBar';
-import styles from './styles.module.scss';
-import { LoaderFillerContainer } from '../Loader';
 import DonationHighlightBox from './DonationHighlightBox';
 import GiftMealHighlightBox from './GiftMealHighlightBox';
+import MerchantCard from './MerchantCard';
+import MerchantDescriptionBanner from './MerchantDescriptionBanner';
+import NavBar from './MerchantNavBar';
+import { LoaderFillerContainer } from '../Loader';
+import { getSellers } from '../../utilities';
+import type { BrowsePageSeller } from '../../utilities/api/types';
 import { getWebsiteImages } from '../../utilities/general/StoreImages';
-import { useTranslation } from 'react-i18next';
-import ReactPixel from 'react-facebook-pixel';
+
+import styles from './styles.module.scss';
 
 interface Props {
   menuOpen: boolean;
 }
+
+type ContributionsType = {
+  donationAmount: number,
+  giftCardAmount: number,
+  giftAMealAmount: number,
+}
+
+const INITIAL_CONTRIBUTIONS: ContributionsType = {
+  donationAmount: 0,
+  giftCardAmount: 0,
+  giftAMealAmount: 0,
+};
 
 ReactPixel.trackCustom('MerchantsPageView', {});
 const MerchantsPage = (props: Props) => {
@@ -23,26 +38,23 @@ const MerchantsPage = (props: Props) => {
   const { t, i18n } = useTranslation();
   const [sellers, setSellers] = useState<any | null>();
   const [filter, setFilter] = useState<any | null>();
-  const [totalDonations, setDonations] = useState(0);
-  const [totalGiftCards, setGiftCards] = useState(0);
+  const [contributions, setContributions] = useState<ContributionsType>(INITIAL_CONTRIBUTIONS);
 
-  const fetchData = async (lang?) => {
+  const fetchData = async (lang?: string) => {
     const { data } = await getSellers(lang);
 
-    const contributions = data.reduce(
-      (total: any, store: any) => {
-        return [
-          total[0] + store.donation_amount,
-          total[1] + store.gift_card_amount,
-        ];
-      },
-      [0, 0]
+    const tempContributions = data.reduce(
+      (totalContributions: ContributionsType, store: BrowsePageSeller) => ({
+        donationAmount: totalContributions.donationAmount + store.donation_amount,
+        giftCardAmount: totalContributions.giftCardAmount + store.gift_card_amount,
+        giftAMealAmount: totalContributions.giftAMealAmount + store.gift_a_meal_amount,
+      }),
+      INITIAL_CONTRIBUTIONS,
     );
 
     setSellers(data);
     setFilter(data);
-    setDonations(contributions[0]);
-    setGiftCards(contributions[1]);
+    setContributions(tempContributions);
   };
 
   useEffect(() => {
@@ -95,8 +107,11 @@ const MerchantsPage = (props: Props) => {
               {/* TODO: hook this part up to actual amounts - is there a total amount api call? */}
               <div className={styles.storeInfo}>
                 <ContributionBar
-                  totalDonations={totalDonations}
-                  totalGiftCards={totalGiftCards}
+                  donationsRaised={contributions.donationAmount}
+                  giftAMealAmountRaised={contributions.giftAMealAmount}
+                  // giftCardAmountRaised includes the amount from the gift-a-meal program.
+                  // Subtract out contributions.giftAMealAmount so we don't overcount.
+                  giftCardAmountRaised={contributions.giftCardAmount - contributions.giftAMealAmount}
                 />
               </div>
             </div>

--- a/src/components/MerchantsPage/MerchantsPage.tsx
+++ b/src/components/MerchantsPage/MerchantsPage.tsx
@@ -21,10 +21,10 @@ interface Props {
 }
 
 type ContributionsType = {
-  donationAmount: number,
-  giftCardAmount: number,
-  giftAMealAmount: number,
-}
+  donationAmount: number;
+  giftCardAmount: number;
+  giftAMealAmount: number;
+};
 
 const INITIAL_CONTRIBUTIONS: ContributionsType = {
   donationAmount: 0,
@@ -38,18 +38,23 @@ const MerchantsPage = (props: Props) => {
   const { t, i18n } = useTranslation();
   const [sellers, setSellers] = useState<any | null>();
   const [filter, setFilter] = useState<any | null>();
-  const [contributions, setContributions] = useState<ContributionsType>(INITIAL_CONTRIBUTIONS);
+  const [contributions, setContributions] = useState<ContributionsType>(
+    INITIAL_CONTRIBUTIONS
+  );
 
   const fetchData = async (lang?: string) => {
     const { data } = await getSellers(lang);
 
     const tempContributions = data.reduce(
       (totalContributions: ContributionsType, store: BrowsePageSeller) => ({
-        donationAmount: totalContributions.donationAmount + store.donation_amount,
-        giftCardAmount: totalContributions.giftCardAmount + store.gift_card_amount,
-        giftAMealAmount: totalContributions.giftAMealAmount + store.gift_a_meal_amount,
+        donationAmount:
+          totalContributions.donationAmount + store.donation_amount,
+        giftCardAmount:
+          totalContributions.giftCardAmount + store.gift_card_amount,
+        giftAMealAmount:
+          totalContributions.giftAMealAmount + store.gift_a_meal_amount,
       }),
-      INITIAL_CONTRIBUTIONS,
+      INITIAL_CONTRIBUTIONS
     );
 
     setSellers(data);
@@ -111,7 +116,9 @@ const MerchantsPage = (props: Props) => {
                   giftAMealAmountRaised={contributions.giftAMealAmount}
                   // giftCardAmountRaised includes the amount from the gift-a-meal program.
                   // Subtract out contributions.giftAMealAmount so we don't overcount.
-                  giftCardAmountRaised={contributions.giftCardAmount - contributions.giftAMealAmount}
+                  giftCardAmountRaised={
+                    contributions.giftCardAmount - contributions.giftAMealAmount
+                  }
                 />
               </div>
             </div>
@@ -141,15 +148,18 @@ const MerchantsPage = (props: Props) => {
           <div className={styles.flyerContainer}>
             <p>
               {t('merchantsPage.flyerAsk') + ' '}
-              <a className={styles.redLink} href="https://www.sendchinatownlove.com/merchant-flyers.html">
+              <a
+                className={styles.redLink}
+                href="https://www.sendchinatownlove.com/merchant-flyers.html"
+              >
                 {t('merchantsPage.flyerDownload')}
               </a>
             </p>
           </div>
         </>
       ) : (
-          <LoaderFillerContainer />
-        )}
+        <LoaderFillerContainer />
+      )}
     </div>
   );
 };

--- a/src/components/MerchantsPage/MerchantsPage.tsx
+++ b/src/components/MerchantsPage/MerchantsPage.tsx
@@ -45,21 +45,21 @@ const MerchantsPage = (props: Props) => {
   const fetchData = async (lang?: string) => {
     const { data } = await getSellers(lang);
 
-    const tempContributions = data.reduce(
-      (totalContributions: ContributionsType, store: BrowsePageSeller) => ({
-        donationAmount:
-          totalContributions.donationAmount + store.donation_amount,
-        giftCardAmount:
-          totalContributions.giftCardAmount + store.gift_card_amount,
-        giftAMealAmount:
-          totalContributions.giftAMealAmount + store.gift_a_meal_amount,
-      }),
-      INITIAL_CONTRIBUTIONS
-    );
-
     setSellers(data);
     setFilter(data);
-    setContributions(tempContributions);
+    setContributions(
+      data.reduce(
+        (totalContributions: ContributionsType, store: BrowsePageSeller) => ({
+          donationAmount:
+            totalContributions.donationAmount + store.donation_amount,
+          giftCardAmount:
+            totalContributions.giftCardAmount + store.gift_card_amount,
+          giftAMealAmount:
+            totalContributions.giftAMealAmount + store.gift_a_meal_amount,
+        }),
+        INITIAL_CONTRIBUTIONS
+      )
+    );
   };
 
   useEffect(() => {

--- a/src/components/MerchantsPage/MerchantsPage.tsx
+++ b/src/components/MerchantsPage/MerchantsPage.tsx
@@ -109,7 +109,6 @@ const MerchantsPage = (props: Props) => {
                 <p>{t('merchantsPage.platformInfoDescription')}</p>
                 <p>{t('merchantsPage.platformInfoAction')}</p>
               </div>
-              {/* TODO: hook this part up to actual amounts - is there a total amount api call? */}
               <div className={styles.storeInfo}>
                 <ContributionBar
                   donationsRaised={contributions.donationAmount}

--- a/src/locales/cn/translation.json
+++ b/src/locales/cn/translation.json
@@ -75,6 +75,7 @@
   },
   "contributionBar": {
     "header": "筹款总额",
+    "giftAMeal": "捐爱心餐",
     "vouchers": "礼品券",
     "donations": "捐款",
     "footer": "所有的收益将会全数送到所需的商家手里。"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -75,6 +75,7 @@
   },
   "contributionBar": {
     "header": "Total Raised",
+    "giftAMeal": "GIFT-A-MEAL",
     "vouchers": "VOUCHERS",
     "donations": "DONATIONS",
     "footer": "100% of all proceeds go to the businesses."

--- a/src/utilities/api/types.ts
+++ b/src/utilities/api/types.ts
@@ -76,6 +76,7 @@ export type BrowsePageSeller = {
   num_gift_cards: number;
   donation_amount: number;
   gift_card_amount: number;
+  gift_a_meal_amount: number;
   progress_bar_color: string;
   summary: string;
   story: string;

--- a/src/utilities/hooks/ModalPaymentContext/types.ts
+++ b/src/utilities/hooks/ModalPaymentContext/types.ts
@@ -33,6 +33,7 @@ export const defaultState: ModalPaymentState = {
     num_donations: 0,
     num_gift_cards: 0,
     donation_amount: 0,
+    gift_a_meal_amount: 0,
     gift_card_amount: 0,
     progress_bar_color: '',
     summary: '',


### PR DESCRIPTION
Add GAM to total contributions bar on all merchants page. Also did a couple refactors in the files I touched / added some more typings. See screenshots below for the contributions bar UI w/ various donation / GAM / gift card amounts.

Depends on: https://github.com/sendchinatownlove/ruby/pull/261
Trello ticket: https://trello.com/c/2Ncvuvix/609-add-gam-in-total-raised-contribution-bar-on-merchants-page

<img width="1287" alt="Screen Shot 2020-10-11 at 2 42 15 PM" src="https://user-images.githubusercontent.com/10658691/95691132-b5236c00-0bd1-11eb-96bd-ab2842727c95.png">

<img width="1296" alt="Screen Shot 2020-10-11 at 2 41 49 PM" src="https://user-images.githubusercontent.com/10658691/95691135-b5bc0280-0bd1-11eb-9224-d35e249bdf07.png">

<img width="1281" alt="Screen Shot 2020-10-11 at 2 41 41 PM" src="https://user-images.githubusercontent.com/10658691/95691136-b6549900-0bd1-11eb-8802-a023a9c85404.png">

<img width="1286" alt="Screen Shot 2020-10-11 at 2 41 27 PM" src="https://user-images.githubusercontent.com/10658691/95691137-b6ed2f80-0bd1-11eb-943d-a992892f628b.png">

<img width="1281" alt="Screen Shot 2020-10-11 at 2 41 16 PM" src="https://user-images.githubusercontent.com/10658691/95691138-b785c600-0bd1-11eb-9461-ad308789c4c5.png">

<img width="1284" alt="Screen Shot 2020-10-11 at 2 37 35 PM" src="https://user-images.githubusercontent.com/10658691/95691139-b81e5c80-0bd1-11eb-9bda-70a4daede701.png">