### PR TITLE
Merchant dashboard v2 - hacky fix for print bug

### DIFF
--- a/src/pages/MerchantVoucherDashboardV2/VoucherTable.tsx
+++ b/src/pages/MerchantVoucherDashboardV2/VoucherTable.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import moment from 'moment';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import Button from '@material-ui/core/Button';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -53,6 +53,21 @@ const VoucherTable = ({
       setLatestValue('');
     }
   }, [editingGiftCard, setErrorType]);
+
+  const tableRef = useRef();
+  useEffect(() => {
+    // This is very hacky but we need it to force the table to re-render
+    // when we print. react-filterable-table only updates page size on
+    // component mount or when an internal .updatePageSize method is
+    // called. See below for details:
+    // https://github.com/ianwitherow/react-filterable-table/blob/master/src/Components/FilterableTable.jsx#L23
+    // https://github.com/ianwitherow/react-filterable-table/blob/master/src/Components/FilterableTable.jsx#L224
+    if (showPrintView) {
+      (tableRef?.current as any).updatePageSize({ target: { value: 1000 } });
+    } else {
+      (tableRef?.current as any).updatePageSize({ target: { value: 20 } });
+    }
+  }, [showPrintView]);
 
   const onSave = useCallback(
     async (giftCardId: string) => {
@@ -221,7 +236,6 @@ const VoucherTable = ({
     },
   ];
 
-  // TODO: Hover and selected background colors.
   return (
     <FilterableTable
       bottomPagerVisible={!showPrintView}
@@ -233,11 +247,10 @@ const VoucherTable = ({
       namespace="Vouchers"
       noFilteredRecordsMessage="No vouchers found for filter"
       noRecordsMessage="No vouchers in our system yet!"
-      // Kind of a hack, but show all of the gift cards if we're in print view.
-      pageSize={showPrintView ? 100000 : 20}
       pageSizes={null} // Don't show the page size chooser.
       recordCountName="Voucher Found"
       recordCountNamePlural="Vouchers Found"
+      ref={tableRef}
       topPagerVisible={false}
     />
   );

--- a/src/pages/MerchantVoucherDashboardV2/styles.module.scss
+++ b/src/pages/MerchantVoucherDashboardV2/styles.module.scss
@@ -199,7 +199,7 @@
   }
 
   .filterGamSelected {
-    color: #a8192e;
+    color: #a8192e !important;
   }
 }
 


### PR DESCRIPTION
Merchant dashboard v2 - hacky fix for print bug. Before, only the first page would render in the print view, so if there were hundreds of gift cards, only the first 20 would be printable. This was basically due to the fact that the react-filterable-table component doesn't rerender when the pageSize prop changes. I created this hacky fix by looking into the internals of the table. We're going to manually call the method that triggers the page size to change in the react-filterable-table.