### PR TITLE
centered merchant and highlight containers on ipad

### DIFF
--- a/src/components/MerchantsPage/styles.module.scss
+++ b/src/components/MerchantsPage/styles.module.scss
@@ -26,6 +26,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, 350px);
   grid-gap: 2.5rem 6rem;
+  justify-content: center;
 
   @media (max-width: 1350px) {
     grid-gap: 2.5rem 5%;
@@ -232,6 +233,7 @@
   grid-gap: 2.5rem 6rem;
   padding-top: 40px;
   padding-bottom: 60px;
+  justify-content: center;
 
   @media (max-width: 1350px) {
     grid-gap: 2.5rem 5%;


### PR DESCRIPTION
Quick CSS fix to center the highlight and merchant containers on iPad (see below; tested with Chrome's developer tools).

I didn't change the sizes of any of the containers so the left and right margins are not the same size, but it should be centered at least. Happy to talk to design about this if its a priority.

**Before** ![image](https://user-images.githubusercontent.com/20375084/97791154-9b0ff480-1ba5-11eb-8ae3-3582b69c2dd3.png)

**After** 
![image](https://user-images.githubusercontent.com/20375084/97791163-abc06a80-1ba5-11eb-8db9-ef95048340bb.png)

