### PR TITLE
Sort past campaigns by recent end date

### DIFF
--- a/src/components/MerchantsPage/gam/GiftAMealPage.tsx
+++ b/src/components/MerchantsPage/gam/GiftAMealPage.tsx
@@ -25,7 +25,9 @@ const GiftAMealPage = (props: Props) => {
       (campaign: any) => campaign.active && campaign.valid
     );
     setActiveCampaigns(active);
-    const past = campaignData.data.filter((campaign: any) => !campaign.active);
+    const past = campaignData.data
+      .filter((campaign: any) => !campaign.active)
+      .reverse();
     setPastCampaigns(past);
   };
 


### PR DESCRIPTION
API endpoint returns campaigns ordered by least recent end date first. We want the past campaigns to show the most recent end date first. So if we `reverse()` on the frontend then it will accomplish this.

We could do `sort(
      (a, b) => a.end_date < b.end_date ? 1 : (a.end_date > b.end_date ? -1 : 0)
    );` if we really wanted to but `reverse()` is good for now.