### PR TITLE
Add null safety check to Projects fetch in LUC progress bar

### DIFF
--- a/src/components/LightUpChinatown/LightUpChinatownPage.tsx
+++ b/src/components/LightUpChinatown/LightUpChinatownPage.tsx
@@ -25,7 +25,9 @@ const LightUpChinatownPage = () => {
 
   const fetchData = async (project_id: number) => {
     const { data } = await getProject(project_id);
-    setContributions(data.amount_raised);
+    if (data) {
+      setContributions(data.amount_raised);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
The LightUpPage won't load on staging/local if there is no backend project. This adds a safety check to make sure it loads