### PR TITLE
Some Light Up Chinatown Page fixes

### DIFF
--- a/src/components/LightUpChinatown/LightUpChinatownPage.tsx
+++ b/src/components/LightUpChinatown/LightUpChinatownPage.tsx
@@ -225,15 +225,17 @@ const PartnerThanksTitle = styled.div`
 `;
 
 const Container = styled.section`
-  max-width: 1440px;
+  width: 90%;
   margin: 0 auto;
-  padding: 0px 25px;
+  padding: 40px 25px 0px;
   align-items: center;
   display: flex;
   flex-direction: column;
   @media (min-width: 900px) {
     display: grid;
     grid-column-gap: 116px;
+    padding-top: 80px;
+    max-width: 1280px;
   }
 `;
 

--- a/src/components/ModalPayment/ModalConfirmation/ModalConfirmation.tsx
+++ b/src/components/ModalPayment/ModalConfirmation/ModalConfirmation.tsx
@@ -26,12 +26,15 @@ const ModalConfirmation = (props: Props) => {
   const closeModal = async (e: any) => {
     ReactPixel.trackCustom('ModalConfirmationButtonClick', {});
     e.preventDefault();
-
-    const { data } = props.sellerId && (await getSeller(props.sellerId));
-    dispatch({
-      type: ModalPaymentConstants.UPDATE_SELLER_DATA,
-      payload: data.amount_raised,
-    });
+    // @TODO(wilsonj806) Replace the below with a proper fix
+    //...for differentiating between a seller and a project
+    if (props.sellerId !== 'light-up-chinatown') {
+      const { data } = props.sellerId && (await getSeller(props.sellerId));
+      dispatch({
+        type: ModalPaymentConstants.UPDATE_SELLER_DATA,
+        payload: data.amount_raised,
+      });
+    }
     dispatch({ type: ModalPaymentConstants.CLOSE_MODAL, payload: undefined });
   };
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -124,11 +124,14 @@ h3 {
   font-family: 'Open Sans';
 
   padding: 8px;
-  width: 120px;
+  width: 100%;
   border-radius: 75px;
   font-size: 12px;
   text-transform: uppercase;
   outline: none;
+  @media (min-width: 900px) {
+    width: 120px;
+  }
 }
 
 .modalButton {


### PR DESCRIPTION
List of Changes
- Modify LUC content max width and add padding to match the mockup 
<img src="https://user-images.githubusercontent.com/12119553/99465354-33c5a480-2908-11eb-9733-d0d91fdd0b2a.png" width="800x"/>

- Fix Finish button on the payment complete modal not spanning the entire screen on mobile devices
- *HOTFIX* LUC modal not closing on pressing the Finish button when a transaction is completed. This should be replaced with a more robust solution that can differentiate between an actual seller_id and a project_id/ something that resembles a project_id
