### PR TITLE
Use seller_distributor_pairs for gam 

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -94,13 +94,16 @@ const CampaignListItem = (props: Props) => {
           <Description>
             {campaign.description}{' '}
             {distributor && (
-              <a
-                href={distributor.website_url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Learn more about {distributor.name}.
-              </a>
+              <span>
+                Learn more about{' '}
+                <a
+                  href={distributor.website_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {distributor.name}.
+                </a>
+              </span>
             )}
           </Description>
           <CampaignProgressBar

--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -37,7 +37,9 @@ const CampaignListItem = (props: Props) => {
 
   const fetchData = async () => {
     const distributorData = await getDistributor(campaign.distributor_id);
-    const merchantData = await getSeller(campaign.seller_id);
+    const seller_id = campaign.seller_distributor_pairs[0].seller_id;
+    const merchantData = await getSeller(seller_id);
+
     setDistributor(distributorData.data);
     setMerchant(merchantData.data);
     if (campaign.nonprofit_id) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37196330/99817062-0e0beb80-2b12-11eb-9c17-d3118f21d28a.png)
front end is broken and isn't showing the seller x distributor title and the learn more about part

we should probably eventually remove distributor_id in campaigns