### PR TITLE
Add fiscal sponsor to mega gam campaign

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -5,11 +5,7 @@ import { tabletScreens } from '../../../utilities/general/responsive';
 import { useTranslation } from 'react-i18next';
 import campaignDefaultImage from '../images/campaign_default.png';
 import { Campaign } from '../../../utilities/api/types';
-import {
-  getDistributor,
-  getSeller,
-  getFiscalSponsor,
-} from '../../../utilities/api';
+import { getDistributor, getSeller } from '../../../utilities/api';
 import { useEffect, useState } from 'react';
 import Modal from '../../ModalPayment';
 import {
@@ -17,6 +13,7 @@ import {
   useModalPaymentDispatch,
   ModalPaymentTypes,
 } from '../../../utilities/hooks/ModalPaymentContext';
+import FiscalSponsor from './FiscalSponsor';
 
 interface Props {
   campaign: Campaign;
@@ -32,7 +29,6 @@ const CampaignListItem = (props: Props) => {
 
   const [distributor, setDistributor] = useState<any | null>();
   const [merchant, setMerchant] = useState<any | null>();
-  const [fiscalSponsor, setFiscalSponsor] = useState<any | null>();
   const campaign = props.campaign;
 
   const fetchData = async () => {
@@ -42,10 +38,6 @@ const CampaignListItem = (props: Props) => {
 
     setDistributor(distributorData.data);
     setMerchant(merchantData.data);
-    if (campaign.nonprofit_id) {
-      const fiscalSponsor = await getFiscalSponsor(campaign.nonprofit_id);
-      setFiscalSponsor(fiscalSponsor.data);
-    }
   };
 
   useEffect(() => {
@@ -154,17 +146,9 @@ const CampaignListItem = (props: Props) => {
           />
         )}
       </Container>
-      {fiscalSponsor && (
+      {campaign.nonprofit_id && (
         <FiscalSponsorContainer>
-          <FiscalSponsorImage
-            src={fiscalSponsor.logo_image_url}
-          ></FiscalSponsorImage>
-          <FiscalSponsorDivider></FiscalSponsorDivider>
-          <FiscalSponsorText>
-            {t('gamHome.listItem.fiscalSponsor', {
-              sponsorName: fiscalSponsor.name,
-            })}
-          </FiscalSponsorText>
+          <FiscalSponsor nonprofitId={campaign.nonprofit_id} />
         </FiscalSponsorContainer>
       )}
       <Border></Border>
@@ -319,50 +303,11 @@ const DistributorImage = styled.img`
 `;
 
 const FiscalSponsorContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  margin-bottom: 55px;
-  position: relative;
-
-  @media (${tabletScreens}) {
-    margin-bottom: 30px;
-  }
-`;
-
-const FiscalSponsorImage = styled.img`
   margin-left: 28%;
-  max-height: 35px;
-  max-width: 80px;
 
   @media (${tabletScreens}) {
-    position: absolute;
-    top: 50%;
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
     margin-left: 0%;
   }
-`;
-
-const FiscalSponsorDivider = styled.div`
-  margin-left: 18px;
-  width: 5px;
-  height: 37px;
-  background-color: #f5ec57;
-
-  @media (${tabletScreens}) {
-    height: 110px;
-    margin-left: 27%;
-  }
-`;
-
-const FiscalSponsorText = styled.div`
-  margin-left: 6px;
-  font-family: Open Sans;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 13px;
-  line-height: 18px;
-  color: #1e1e1e;
 `;
 
 const Border = styled.div`

--- a/src/components/MerchantsPage/gam/FiscalSponsor.tsx
+++ b/src/components/MerchantsPage/gam/FiscalSponsor.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import type { Nonprofit } from '../../../utilities/api/types';
+import { getFiscalSponsor } from '../../../utilities/api';
+import { tabletScreens } from '../../../utilities/general/responsive';
+
+interface Props {
+  nonprofitId: number;
+}
+
+const FiscalSponsor = ({ nonprofitId }: Props) => {
+  const { t } = useTranslation();
+
+  const [fiscalSponsor, setFiscalSponsor] = useState<Nonprofit | null>(null);
+
+  const fetchData = async () => {
+    const fiscalSponsor = await getFiscalSponsor(nonprofitId);
+    setFiscalSponsor(fiscalSponsor.data);
+  };
+
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!fiscalSponsor) {
+    return null;
+  }
+
+  return (
+    <FiscalSponsorContainer>
+      <FiscalSponsorImage
+        src={fiscalSponsor.logo_image_url}
+      ></FiscalSponsorImage>
+      <FiscalSponsorDivider></FiscalSponsorDivider>
+      <FiscalSponsorText>
+        {t('gamHome.listItem.fiscalSponsor', {
+          sponsorName: fiscalSponsor.name,
+        })}
+      </FiscalSponsorText>
+    </FiscalSponsorContainer>
+  );
+};
+
+const FiscalSponsorContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-bottom: 55px;
+  position: relative;
+
+  @media (${tabletScreens}) {
+    justify-content: flex-start;
+    margin: 0 24px 30px 24px;
+  }
+`;
+
+const FiscalSponsorImage = styled.img`
+  max-height: 35px;
+  max-width: 80px;
+
+  @media (${tabletScreens}) {
+    position: absolute;
+    top: 50%;
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+    margin-left: 0%;
+  }
+`;
+
+const FiscalSponsorDivider = styled.div`
+  margin-left: 18px;
+  width: 5px;
+  height: 37px;
+  background-color: #f5ec57;
+
+  @media (${tabletScreens}) {
+    height: 110px;
+    margin-left: 27%;
+  }
+`;
+
+const FiscalSponsorText = styled.div`
+  display: flex;
+  align-items: center;
+  margin-left: 6px;
+  font-family: Open Sans;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 13px;
+  line-height: 18px;
+  color: #1e1e1e;
+  max-width: 760px;
+`;
+
+export default FiscalSponsor;

--- a/src/components/MerchantsPage/gam/FiscalSponsor.tsx
+++ b/src/components/MerchantsPage/gam/FiscalSponsor.tsx
@@ -74,7 +74,8 @@ const FiscalSponsorDivider = styled.div`
   margin-left: 18px;
   width: 5px;
   height: 37px;
-  background-color: #f5ec57;
+  background-color: #f8ba17;
+  flex-shrink: 0;
 
   @media (${tabletScreens}) {
     height: 110px;

--- a/src/components/MerchantsPage/gam/MegaGamListItem/MegaGamListItem.tsx
+++ b/src/components/MerchantsPage/gam/MegaGamListItem/MegaGamListItem.tsx
@@ -7,6 +7,7 @@ import type {
   SellerDistributorPair as SellerDistributorPairType,
 } from '../../../../utilities/api/types';
 import { tabletScreens } from '../../../../utilities/general/responsive';
+import FiscalSponsor from '../FiscalSponsor';
 import MegaGamProgressBar from './MegaGamProgressBar';
 import SellerDistributorPair from './SellerDistributorPair';
 
@@ -55,7 +56,14 @@ const MegaGamListItem = ({ campaign }: Props) => {
           </SellerDistributorPairs>
         </SellerDistributorContent>
       </Content>
-      {/* TODO: Add fiscal sponsor. */}
+      {campaign.nonprofit_id && (
+        <div>
+          <Divider />
+          <FiscalSponsorContainer>
+            <FiscalSponsor nonprofitId={campaign.nonprofit_id} />
+          </FiscalSponsorContainer>
+        </div>
+      )}
     </Container>
   );
 };
@@ -167,5 +175,12 @@ const SellerDistributorPairs = styled.div`
     margin-right: 28px;
   }
 `;
+
+const Divider = styled.div`
+  border-bottom: 1px solid #e5e5e5;
+  margin: 0 10% 58px 10%;
+`;
+
+const FiscalSponsorContainer = styled.div``;
 
 export default MegaGamListItem;

--- a/src/utilities/api/interactionManager.ts
+++ b/src/utilities/api/interactionManager.ts
@@ -207,7 +207,7 @@ export const getDistributor = async (id: string): Promise<any> => {
     .catch((err) => err);
 };
 
-export const getFiscalSponsor = async (id: string): Promise<any> => {
+export const getFiscalSponsor = async (id: number): Promise<any> => {
   return await axios
     .get(nonprofits + id)
     .then((res) => res)

--- a/src/utilities/api/types.ts
+++ b/src/utilities/api/types.ts
@@ -135,7 +135,7 @@ export type Campaign = {
   id: number;
   last_contribution: string;
   location_id: string;
-  nonprofit_id: string;
+  nonprofit_id: number | null;
   project_id: number;
   price_per_meal: number;
   seller_id: string;
@@ -143,4 +143,14 @@ export type Campaign = {
   target_amount: number;
   updated_at: string;
   valid: boolean;
+};
+
+export type Nonprofit = {
+  contact_id: number;
+  created_at: string;
+  fee_id: number;
+  id: number;
+  logo_image_url: string;
+  name: string;
+  updated_at: string;
 };


### PR DESCRIPTION
Add fiscal sponsor to mega gam campaign. Created a shared FiscalSponsor component to be used by regular and mega gam campaigns

Desktop:
<img width="1211" alt="Screen Shot 2020-12-01 at 5 43 06 PM" src="https://user-images.githubusercontent.com/10658691/100817366-df88ed00-33fc-11eb-98f8-82eb5542d6ed.png">

Mobile:
<img width="409" alt="Screen Shot 2020-12-01 at 5 42 54 PM" src="https://user-images.githubusercontent.com/10658691/100817369-e3b50a80-33fc-11eb-9461-f5f1974d5f72.png">
