### PR TITLE
Fix margin on campaign list item image

### DIFF
--- a/src/components/MerchantsPage/gam/CampaignListItem.tsx
+++ b/src/components/MerchantsPage/gam/CampaignListItem.tsx
@@ -257,7 +257,7 @@ const Button = styled.div`
 
 const ImagesContainer = styled.span`
   align-self: right;
-  margin-bottom: 140px;
+  margin-bottom: auto;
   align-self: flex-end;
 
   @media (${tabletScreens}) {


### PR DESCRIPTION
Before:
<img width="1186" alt="Screen Shot 2020-12-03 at 6 12 57 PM" src="https://user-images.githubusercontent.com/10658691/101112955-44764b80-3593-11eb-81ab-8dea3a3ae74a.png">

After:
<img width="1194" alt="Screen Shot 2020-12-03 at 6 13 19 PM" src="https://user-images.githubusercontent.com/10658691/101112965-46d8a580-3593-11eb-857e-eeef2faa54e1.png">
