### PR TITLE
Payment modal quick fix

### DIFF
--- a/src/components/ModalPayment/ModalAmount/ModalAmount.tsx
+++ b/src/components/ModalPayment/ModalAmount/ModalAmount.tsx
@@ -269,6 +269,7 @@ const TransactionFeeContainer = styled.div`
 const TotalContainer = styled.div`
   display: flex;
   justify-content: flex-end;
+  margin-top: 25px;
   span {
     color: #dd678a;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -122,16 +122,12 @@ h3 {
 
 @mixin modal-button {
   font-family: 'Open Sans';
-
   padding: 8px;
-  width: 100%;
+  width: 120px;
   border-radius: 75px;
   font-size: 12px;
   text-transform: uppercase;
   outline: none;
-  @media (min-width: 900px) {
-    width: 120px;
-  }
 }
 
 .modalButton {


### PR DESCRIPTION
Added margin to fix:
![paymentStart](https://user-images.githubusercontent.com/37196330/101260173-f597f580-36fb-11eb-8ff1-8bad08b7a844.PNG)

Reverted to original button styling as the confirm button looks like this on mobile:
![paymentConfirm](https://user-images.githubusercontent.com/37196330/101260117-7e626180-36fb-11eb-8635-a4c8e47b008e.PNG)
We can make the modal button width back to 100% when we decide to move the back button to the top of the modal