### PR TITLE
Replace button effect with donation pool modal

### DIFF
--- a/src/components/MerchantsPage/gam/NoCampaignsBox.tsx
+++ b/src/components/MerchantsPage/gam/NoCampaignsBox.tsx
@@ -5,9 +5,25 @@ import {
 } from '../../../utilities/general/responsive';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import {
+  useModalPaymentDispatch,
+  ModalPaymentConstants,
+  ModalPaymentTypes,
+} from '../../../utilities/hooks/ModalPaymentContext';
+import Modal from '../../ModalPayment';
 
 const NoActiveCampaignsBox = () => {
   const { t } = useTranslation();
+
+  const ModalPaymentDispatcher = useModalPaymentDispatch(null);
+
+  const openModal = (event) => {
+    event.preventDefault();
+    ModalPaymentDispatcher({
+      type: ModalPaymentConstants.SET_MODAL_VIEW,
+      payload: ModalPaymentTypes.modalPages.donation,
+    });
+  };
 
   return (
     <NoCampaignBox>
@@ -15,15 +31,14 @@ const NoActiveCampaignsBox = () => {
         <Heading>{t('gamHome.noCampaignsBox.CTA')}</Heading>
         <SubHeading>{t('gamHome.noCampaignsBox.description')}</SubHeading>
       </TextContainer>
-      <Button
-        className="button--filled"
-        onClick={(e) => {
-          e.preventDefault();
-          window.open('https://www.gofundme.com/f/gift-a-meal', '_blank');
-        }}
-      >
+      <Button className="button--filled" onClick={openModal}>
         {t('gamHome.giftButton')}
       </Button>
+      <Modal
+        sellerId="send-chinatown-love"
+        sellerName="Send Chinatown Love"
+        costPerMeal={0}
+      />
     </NoCampaignBox>
   );
 };


### PR DESCRIPTION
When no campaigns are active, the gift-a-meal button defaults to a link to the GoFundMe page. Instead, the button should now open a the pooled donation modal.

![image](https://user-images.githubusercontent.com/38918961/101313145-85848f00-3823-11eb-9bf7-a3ab43634fb8.png)
