### PR TITLE
Seller name in disclaimer

### DIFF
--- a/src/components/ModalPayment/ModalCardDetails/ModalCardDetails.tsx
+++ b/src/components/ModalPayment/ModalCardDetails/ModalCardDetails.tsx
@@ -247,20 +247,15 @@ const ModalCardDetails = ({
 
     switch (type) {
       case ModalPaymentTypes.modalPages.donation:
-        return t(
-          'modalPayment.modalCardDetails.disclaimer.donation',
-          sellerName
-        );
+        return t('modalPayment.modalCardDetails.disclaimer.donation', {
+          sellerName: sellerName,
+        });
       case ModalPaymentTypes.modalPages.donation_pool:
-        return t(
-          'modalPayment.modalCardDetails.disclaimer.donation_pool',
-          sellerName
-        );
+        return t('modalPayment.modalCardDetails.disclaimer.donation_pool');
       case ModalPaymentTypes.modalPages.gift_card:
-        return t(
-          'modalPayment.modalCardDetails.disclaimer.gift_card',
-          sellerName
-        );
+        return t('modalPayment.modalCardDetails.disclaimer.gift_card', {
+          sellerName: sellerName,
+        });
       case ModalPaymentTypes.modalPages.light_up_chinatown:
         return t('modalPayment.modalCardDetails.disclaimer.light_up_chinatown');
       default:


### PR DESCRIPTION
Bug:
![bug](https://user-images.githubusercontent.com/37196330/101708585-8c95e200-3a5b-11eb-9446-e394149d6742.PNG)

![paymentConfirm1](https://user-images.githubusercontent.com/37196330/101708155-b4387a80-3a5a-11eb-81b0-a03c4e8acb27.PNG)
![PaymentConfirm2](https://user-images.githubusercontent.com/37196330/101708198-c6b2b400-3a5a-11eb-82d4-9b19630caf17.PNG)
Fixed bug and removed sellerName since Donation Pool disclaimer doesn't take a sellerName
