### PR TITLE
Mega-GAM: Use React-Markdown for description render

### DIFF
--- a/src/components/MerchantsPage/gam/MegaGamListItem/MegaGamListItem.tsx
+++ b/src/components/MerchantsPage/gam/MegaGamListItem/MegaGamListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-
+import ReactMarkdown from 'react-markdown';
 import type {
   Campaign,
   SellerDistributorPair as SellerDistributorPairType,
@@ -56,7 +56,9 @@ const MegaGamListItem = ({ campaign }: Props) => {
           {/* TODO: Figure out what text will go in the header (i.e. blue text) for future mega gam campaigns */}
           <Header></Header>
           <Subheader>{campaign.display_name}</Subheader>
-          <Description>{campaign.description}</Description>
+          <Description>
+            <ReactMarkdown source={campaign.description} />
+          </Description>
           <DonationContainer>
             <CampaignProgressBar
               endDate={campaign.end_date}
@@ -227,7 +229,6 @@ const Subheader = styled.div`
 const Description = styled.div`
   font-size: 18px;
   margin-bottom: 24px;
-  white-space: pre-line;
   @media (${tabletScreens}) {
     font-size: 14px;
   }


### PR DESCRIPTION

![megagam0](https://user-images.githubusercontent.com/37196330/103823317-7ddd2380-5037-11eb-9ffe-ed9e4f266d6a.PNG)

- We have used React-Markdown before https://github.com/sendchinatownlove/sendchinatownlove.github.io/pull/328/files 
- To link Apex for Youth, the description needs to be updated to: 
`That’s why we’re teaming up with [Apex for Youth](https://www.apexforyouth.org/)`
