### PR TITLE
Update no active GAM campaigns button modal text and set modal footer text

### DIFF
--- a/src/components/ModalPayment/ModalAmount/ModalAmount.tsx
+++ b/src/components/ModalPayment/ModalAmount/ModalAmount.tsx
@@ -90,6 +90,9 @@ export const ModalAmount = (props: Props) => {
 
     switch (purchaseType) {
       case ModalPaymentTypes.modalPages.donation:
+        if (sellerName === 'Apex for Youth') {
+          return t('purchase.donationDefault');
+        }
         return t('purchase.donation', { seller: sellerName });
       case ModalPaymentTypes.modalPages.gift_card:
         return t('purchase.voucher', { seller: sellerName });
@@ -204,18 +207,25 @@ export const ModalAmount = (props: Props) => {
           <span>{formatCurrency(Number(amount) * 100 + feesAmount)}</span>
         </b>
       </TotalContainer>
-      <NextButton
-        type="button"
-        className={'modalButton--filled'}
-        onClick={openModal}
-        disabled={
-          Number(amount) < CUSTOM_AMOUNT_MIN ||
-          Number(amount) > CUSTOM_AMOUNT_MAX ||
-          !validAmount(amount)
-        }
-      >
-        {t('paymentProcessing.amount.submit')}
-      </NextButton>
+      <Footer>
+        <ButtonContainer>
+          <button
+            type="button"
+            className={'modalButton--filled'}
+            onClick={openModal}
+            disabled={
+              Number(amount) < CUSTOM_AMOUNT_MIN ||
+              Number(amount) > CUSTOM_AMOUNT_MAX ||
+              !validAmount(amount)
+            }
+          >
+            {t('paymentProcessing.amount.submit')}
+          </button>
+        </ButtonContainer>
+        {modalView === ModalPaymentTypes.modalPages.donation && (
+          <Disclaimer>{t('purchase.footer')}</Disclaimer>
+        )}
+      </Footer>
     </ContentContainer>
   );
 };
@@ -291,11 +301,19 @@ const ErrorMessage = styled.div`
   font-size: 13px;
 `;
 
-const NextButton = styled.button`
-  position: relative;
-  float: right;
-  right: 0px;
-  bottom: -25px;
+const Footer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const ButtonContainer = styled.div`
+  text-align: right;
+  padding-top: 25px;
+`;
+
+const Disclaimer = styled.div`
+  margin-top: 25px;
 `;
 
 const Header = styled.div`

--- a/src/locales/cn/translation.json
+++ b/src/locales/cn/translation.json
@@ -57,6 +57,8 @@
     "meals": "meals"
   },
   "purchase": {
+    "footer": "Certain Gift-a-Meal campaigns will be conducted in partnership with Apex for Youth, a 501(c)(3) nonprofit organization. If a campaign is denoted as such, contributions will be tax deductible.",
+    "donationDefault": "Gift-A-Meal Donation",
     "donation": "捐款 - {{seller}}",
     "voucher": "购买礼品券 - {{seller}}"
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,7 +1,7 @@
 {
   "paymentProcessing": {
     "amount": {
-      "header": "100% of your support will go to the merchant toward their operating costs. Your transaction is secure, encrypted and directly goes to the owner for sustaining their business.",
+      "header": "100% of your donation will feed communities in need through Send Chinatown’s Love Gift-a-Meal program. Your transaction is secure and encrypted.",
       "light_up_chinatown": "100% of donation goes towards permanent light fixtures throughout Chinatown.",
       "mega_gam": "Please add your payment information below.",
       "label1": "Select amount",
@@ -90,6 +90,8 @@
     "meals": "meals"
   },
   "purchase": {
+    "footer": "Certain Gift-a-Meal campaigns will be conducted in partnership with Apex for Youth, a 501(c)(3) nonprofit organization. If a campaign is denoted as such, contributions will be tax deductible.",
+    "donationDefault": "Gift-A-Meal Donation",
     "donation": "Donation for {{seller}}",
     "voucher": "Voucher for {{seller}}",
     "donation_to": "Donation to {{seller}}",


### PR DESCRIPTION
Trello Card: https://trello.com/c/9kWVBoet/780-update-no-active-gam-campaigns-button-modal-text

<img width="1112" alt="Screen Shot 2021-01-09 at 9 46 11 PM" src="https://user-images.githubusercontent.com/2081510/104113081-20a9d200-52c4-11eb-8cbb-47f4ad60ae5a.png">

I can't figure out why the `<p>` footer text won't take up the entire width in chrome, unfortunately, but I figure it's a minor piece.

Just to clarify the word done:

- Header and body changes to Gift-a-Meal Donation for when there isn't a campaign
- Footer with the disclaimer always shows for all scenarios

It's not great that I have that if statement there, but the work to change the structure, I think, may be a bit more than expected. Do we want to eventually remove business logic from the `Modal` component so the callers just pass in what it wants to render?