### PR TITLE
Hard-coding LUC amount raised

### DIFF
--- a/src/components/LightUpChinatown/LightUpChinatownPage.tsx
+++ b/src/components/LightUpChinatown/LightUpChinatownPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import lanternHeroTop from './images/lantern-hero-top.png';
 import costBreakdownImg from './images/cost-breakdown.png';
@@ -14,7 +13,6 @@ import DonationProgressBar from './DonationProgressBar';
 import LightUpFaq from './LightUpFaq';
 import LightUpPartners from './LightUpPartners';
 import DonationRedirect from './DonationRedirect';
-import { getProject, light_up_chinatown_id } from '../../utilities/api';
 
 const LightUpChinatownPage = () => {
   const { t } = useTranslation();
@@ -24,18 +22,9 @@ const LightUpChinatownPage = () => {
   // const campaignEndDate = new Date('12/20/2020');
   // const timeUntilEnd = campaignEndDate.getTime() - today.getTime();
   // const daysUntilEnd = Math.ceil(timeUntilEnd / (1000 * 3600 * 24));
-  const [contributions, setContributions] = useState<number>(0);
 
-  const fetchData = async (project_id: number) => {
-    const { data } = await getProject(project_id);
-    if (data) {
-      setContributions(data.amount_raised);
-    }
-  };
-
-  useEffect(() => {
-    fetchData(light_up_chinatown_id);
-  }, []);
+  // @NOTE (jacob): the campaign has ended, so let's save the backend some stress and hard-code this number
+  const contributions = 4785900;
 
   return (
     // Need to update topBanner to styled component

--- a/src/components/LightUpChinatown/LightUpChinatownPage.tsx
+++ b/src/components/LightUpChinatown/LightUpChinatownPage.tsx
@@ -24,7 +24,7 @@ const LightUpChinatownPage = () => {
   // const daysUntilEnd = Math.ceil(timeUntilEnd / (1000 * 3600 * 24));
 
   // @NOTE (jacob): the campaign has ended, so let's save the backend some stress and hard-code this number
-  const contributions = 4785900;
+  const contributions = 4832802;
 
   return (
     // Need to update topBanner to styled component


### PR DESCRIPTION
We're seeing a bunch of errors on the back-end as the query for all the amount raised for LUC is huge now! (Kudos to us!). Let's save our backend some stress and hard-code this number as the campaign's closed anyway.

Screenshot of all recent timeout failures on this endpoint:
<img width="706" alt="Screen Shot 2021-02-02 at 8 15 58 PM" src="https://user-images.githubusercontent.com/2818246/106684074-b9fe9800-6593-11eb-9334-04bd38888aa4.png">


(It's also not the most optimal query, but we can fix that separately)