### PR TITLE
Add arrow buttons for Store Gallery Tab Images Modal

### DIFF
--- a/src/components/StoreInfo/StoreGalleryTab.tsx
+++ b/src/components/StoreInfo/StoreGalleryTab.tsx
@@ -19,7 +19,7 @@ const StoreGallery: React.SFC<Props> = ({ seller, expandImage }) => {
             src={image}
             className={`item-${idx + 1}`}
             alt="store-menu"
-            onClick={() => expandImage(image)}
+            onClick={() => expandImage(image, idx)}
           />
         );
       })}

--- a/src/components/StoreInfo/StoreInfoContainer.tsx
+++ b/src/components/StoreInfo/StoreInfoContainer.tsx
@@ -157,17 +157,21 @@ export const StoreInfo: FC<Props> = ({
 
       <ImageModal style={{ display: showModal ? 'block' : 'none' }}>
         <CloseButton onClick={() => setShowModal(false)}>×</CloseButton>
-        <ArrowBackIosIcon
-          onClick={() => {
-            updateImageIndex(imageIndex - 1);
-          }}
-        />
+        <LeftBumper>
+          <ArrowBackIosIcon
+            onClick={() => {
+              updateImageIndex(imageIndex - 1);
+            }}
+          />
+        </LeftBumper>
         <img src={viewImage} alt="modal view" />
-        <ArrowForwardIosIcon
-          onClick={() => {
-            updateImageIndex(imageIndex + 1);
-          }}
-        />
+        <RightBumper>
+          <ArrowForwardIosIcon
+            onClick={() => {
+              updateImageIndex(imageIndex + 1);
+            }}
+          />
+        </RightBumper>
       </ImageModal>
     </section>
   );
@@ -262,4 +266,19 @@ const CloseButton = styled.button`
   border: none;
   outline: none;
   z-index: 2;
+`;
+
+const BaseBumper = styled.button`
+  position: fixed;
+  top: 50%;
+  border-radius: 50%;
+  z-index: 2;
+`;
+
+const LeftBumper = styled(BaseBumper)`
+  left: 0;
+`;
+
+const RightBumper = styled(BaseBumper)`
+  right: 0;
 `;

--- a/src/components/StoreInfo/StoreInfoContainer.tsx
+++ b/src/components/StoreInfo/StoreInfoContainer.tsx
@@ -14,6 +14,8 @@ import styles from './styles.module.scss';
 import defaultStoreFront from './misc-store.png';
 import { useMedia } from 'use-media';
 import { OrderNow, MobileOrderWrapper } from '../OwnerPanel';
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
+import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 
 type Props = {
   seller: BrowsePageSeller;
@@ -31,13 +33,30 @@ export const StoreInfo: FC<Props> = ({
   const showAltLayout = useMedia({ maxWidth: 900 });
   const { summary, story, cuisine_name, locations, website_url } = seller;
 
+  console.log('hello world!');
+  seller.gallery_image_urls = [
+    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-1.png',
+    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-2.png',
+    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-3.png',
+  ];
   // modal functionality for menu and gallery tabs
   const [viewImage, setViewImage] = useState('');
   const [showModal, setShowModal] = useState(false);
+  const [imageIndex, setImageIndex] = useState(-1);
 
-  const expandImage = (url: string) => {
+  const expandImage = (url: string, index: number) => {
     setViewImage(url);
     setShowModal(true);
+    setImageIndex(index);
+  };
+
+  const updateImageIndex = (index: number) => {
+    if (index < 0 || index >= seller.gallery_image_urls.length) {
+      return;
+    }
+
+    setViewImage(seller.gallery_image_urls[index]);
+    setImageIndex(index);
   };
 
   // logic for nav bar & tab switching
@@ -138,7 +157,17 @@ export const StoreInfo: FC<Props> = ({
 
       <ImageModal style={{ display: showModal ? 'block' : 'none' }}>
         <CloseButton onClick={() => setShowModal(false)}>×</CloseButton>
+        <ArrowBackIosIcon
+          onClick={() => {
+            updateImageIndex(imageIndex - 1);
+          }}
+        />
         <img src={viewImage} alt="modal view" />
+        <ArrowForwardIosIcon
+          onClick={() => {
+            updateImageIndex(imageIndex + 1);
+          }}
+        />
       </ImageModal>
     </section>
   );

--- a/src/components/StoreInfo/StoreInfoContainer.tsx
+++ b/src/components/StoreInfo/StoreInfoContainer.tsx
@@ -47,7 +47,7 @@ export const StoreInfo: FC<Props> = ({
   const expandImage = (url: string, index: number) => {
     setViewImage(url);
     setShowModal(true);
-    setImageIndex(index);
+    setImageIndex(index ? index : -1);
   };
 
   const updateImageIndex = (index: number) => {

--- a/src/components/StoreInfo/StoreInfoContainer.tsx
+++ b/src/components/StoreInfo/StoreInfoContainer.tsx
@@ -33,12 +33,6 @@ export const StoreInfo: FC<Props> = ({
   const showAltLayout = useMedia({ maxWidth: 900 });
   const { summary, story, cuisine_name, locations, website_url } = seller;
 
-  console.log('hello world!');
-  seller.gallery_image_urls = [
-    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-1.png',
-    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-2.png',
-    'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/46-mott/46-mott-gallery-3.png',
-  ];
   // modal functionality for menu and gallery tabs
   const [viewImage, setViewImage] = useState('');
   const [showModal, setShowModal] = useState(false);

--- a/src/components/StoreInfo/StoreInfoContainer.tsx
+++ b/src/components/StoreInfo/StoreInfoContainer.tsx
@@ -273,6 +273,8 @@ const BaseBumper = styled.button`
   top: 50%;
   border-radius: 50%;
   z-index: 2;
+  height: 33px;
+  width: 33px;
 `;
 
 const LeftBumper = styled(BaseBumper)`


### PR DESCRIPTION
[Ticket](https://trello.com/c/gdtAR4zu/498-add-arrow-buttons-for-the-gallery-images-so-you-can-click-through-them-in-modal-view)

Description:
Adds bumper buttons for a store's gallery modal so the user 
can scroll through the images without having to exit the Modal.

![2021-02-22 21 38 11](https://user-images.githubusercontent.com/19179930/108806381-64942600-7556-11eb-8ec8-867946b82097.gif)
