### PR TITLE
Update checkout confirmation text

### DIFF
--- a/src/components/ModalPayment/ModalConfirmation/ModalConfirmation.tsx
+++ b/src/components/ModalPayment/ModalConfirmation/ModalConfirmation.tsx
@@ -47,15 +47,21 @@ const ModalConfirmation = (props: Props) => {
   const confirmationText = (purchaseType, sellerName, amount) => {
     switch (purchaseType) {
       case ModalPaymentTypes.modalPages.donation:
-        return `We appreciate your support. We'll let you know when ${sellerName} receives your donation!`;
+        return t('modalPayment.modalConfirmation.donation', {
+          seller: sellerName,
+        });
       case ModalPaymentTypes.modalPages.light_up_chinatown:
         if (amount >= LIGHT_UP_CHINATOWN_TIER_2_MIN)
-          return 'You will receive an email in the next couple weeks about our Lighting Ceremony in December.';
-        return `You will receive an email with receipt for your donation.`;
+          return t('modalPayment.modalConfirmation.lightUpMaxTier');
+        return t('modalPayment.modalConfirmation.lightUpMinTier');
       case ModalPaymentTypes.modalPages.gift_card:
-        return `We appreciate your support. We'll email you your voucher when ${sellerName} opens back up!`;
+        return t('modalPayment.modalConfirmation.voucher', {
+          seller: sellerName,
+        });
       case ModalPaymentTypes.modalPages.buy_meal:
-        return `We appreciate your support for ${sellerName} and for those in need! Please check your email for your receipt.`;
+        return t('modalPayment.modalConfirmation.buyMeal', {
+          seller: sellerName,
+        });
       case ModalPaymentTypes.modalPages.mega_gam:
         return (
           <span>

--- a/src/locales/cn/translation.json
+++ b/src/locales/cn/translation.json
@@ -119,8 +119,13 @@
         "luc_address": "Shipping Address: "
       },
       "modalConfirmation": {
+        "buyMeal": "We appreciate your support for {{seller}} and for those in need! Please check your email for your receipt.",
+        "donation": "We appreciate your support for {{seller}}! You will receive an email receipt shortly with the details of your donation.",
+        "lightUpMinTier": "You will receive an email in the next couple weeks about our Lighting Ceremony in December.",
+        "lightUpMaxTier": "You will receive an email with receipt for your donation.",
         "mega_gam_line_1": "You’ve lent a helping hand to community members and small businesses when they needed it most. Together, we can back those most impacted by the pandemic and keep the city’s Chinatowns vibrant.",
-        "mega_gam_line_2": "You will receive an email receipt shortly with the details of your donation."
+        "mega_gam_line_2": "You will receive an email receipt shortly with the details of your donation.",
+        "voucher": "We appreciate your support for {{seller}}! You will receive an email receipt shortly with the details of your voucher."  
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -153,8 +153,13 @@
       }
     },
     "modalConfirmation": {
+      "buyMeal": "We appreciate your support for {{seller}} and for those in need! Please check your email for your receipt.",
+      "donation": "We appreciate your support for {{seller}}! You will receive an email receipt shortly with the details of your donation.",
+      "lightUpMinTier": "You will receive an email in the next couple weeks about our Lighting Ceremony in December.",
+      "lightUpMaxTier": "You will receive an email with receipt for your donation.",
       "mega_gam_line_1": "You’ve lent a helping hand to community members and small businesses when they needed it most. Together, we can back those most impacted by the pandemic and keep the city’s Chinatowns vibrant.",
-      "mega_gam_line_2": "You will receive an email receipt shortly with the details of your donation."
+      "mega_gam_line_2": "You will receive an email receipt shortly with the details of your donation.",
+      "voucher": "We appreciate your support for {{seller}}! You will receive an email receipt shortly with the details of your voucher."
     }
   },
   "merchantNavBar": {


### PR DESCRIPTION
Outdated confirmation text, currently looks like this:
![image](https://user-images.githubusercontent.com/37196330/115039282-500d4380-9e9e-11eb-8054-5dfddf17d59e.png)
Moved things into the translation files instead of hardcoding. 

The original trello card https://trello.com/c/EgneaM8N/750-voucher-check-out-page-and-receipt-needs-to-be-updated?menu=filter&filter=alice,label:Engineering