### PR TITLE
Sticky navbar

### DIFF
--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -230,7 +230,7 @@ const HeaderContainer = styled.header`
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    z-index: 10;
+    z-index: ${theme.maxzIndex};
     background-color: white;
     border-bottom: 1px solid #f2f2f2;
     width: 100%;
@@ -279,11 +279,17 @@ const NavLinkStyle = styled.a`
   color: black;
   transition: 0.1s;
   margin: 0 20px;
+
+  @media (${smallScreens}) {
+    background-color: white;
+  }
+
   ${(props: CompactProps) =>
     props.compact === 'true' &&
     `
     width: 100%;
-    margin: 16px auto;
+    margin: 0 auto;
+    padding: 16px 0;
     text-align: center;
   `} :link {
     color: black;
@@ -344,6 +350,10 @@ const ReactNavLink = styled.a`
   color: black;
   transition: 0.1s;
   margin: 0 20px;
+
+  @media (${smallScreens}) {
+    background-color: white;
+  }
   ${(props: CompactProps) =>
     props.compact === 'true' &&
     `

--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -97,7 +97,7 @@ const NavBar = (props: Props) => {
     ) : (
       <NavLinksContainer compact={hamburgerOpen.toString()}>
         <HeaderContainer compact={hamburgerOpen.toString()}>
-          <a href="https://sendchinatownlove.com/">
+          <a className="nav-bar-logo" href="https://sendchinatownlove.com/">
             <Logo />
           </a>
           <Close onClick={(e) => props.setMenuOpen(false)} />
@@ -141,7 +141,7 @@ const NavBar = (props: Props) => {
   };
   return (
     <HeaderContainer compact={hamburgerOpen.toString()}>
-      <a href="https://sendchinatownlove.com/">
+      <a className="nav-bar-logo" href="https://sendchinatownlove.com/">
         <Logo />
       </a>
       {hamburgerOpen ? (
@@ -223,7 +223,7 @@ const HeaderContainer = styled.header`
   `}
 
   @media (${smallScreens}) {
-    a {
+    a.nav-bar-logo {
       margin-left: 19px;
     }
 
@@ -366,6 +366,10 @@ const ReactNavLink = styled.a`
 
 const Close = styled(CloseIcon)`
   cursor: pointer;
+
+  @media (${smallScreens}) {
+    margin-right: 20px;
+  }
 `;
 
 const Dropdown = styled.div`

--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import { Logo } from '../Logos';
 import { Page } from '../../consts';
+import { smallScreens } from '../../utilities/general/responsive';
 
 interface Props {
   menuOpen: boolean;
@@ -221,13 +222,21 @@ const HeaderContainer = styled.header`
     margin-top: 40px;
   `}
 
-  @media (max-width: 600px) {
-    background-color: white;
-    width: 100%;
-    padding-bottom: 30px;
+  @media (${smallScreens}) {
+    a {
+      margin-left: 19px;
+    }
+
     position: sticky;
     position: -webkit-sticky;
     top: 0;
+    z-index: 10;
+    background-color: white;
+    border-bottom: 1px solid #f2f2f2;
+    width: 100%;
+    padding-top: 15px;
+    padding-bottom: 30px;
+    margin: 0;
   }
 `;
 
@@ -259,6 +268,10 @@ const HamburgerContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
+  @media (${smallScreens}) {
+    margin-right: 20px;
+  }
 `;
 
 const NavLinkStyle = styled.a`

--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -220,6 +220,15 @@ const HeaderContainer = styled.header`
     `
     margin-top: 40px;
   `}
+
+  @media (max-width: 600px) {
+    background-color: white;
+    width: 100%;
+    padding-bottom: 30px;
+    position: sticky;
+    position: -webkit-sticky;
+    top: 0;
+  }
 `;
 
 const NavLinksContainer = styled.div`


### PR DESCRIPTION
Changing the NavBar to be sticky during mobile viewport sizes.

Two things to note:
- It looks like for whatever reason styled-components isn't updating based on prop changes here - https://github.com/sendchinatownlove/sendchinatownlove.github.io/blob/5217c9e7c7ab5079d21d2656ee5086c0bb277419/src/components/Footer/Footer.tsx#L50 As a result, I opted for a fairly janky solution of changing the `NavLink` margins to padding instead and hiding the footer behind a white background. Not perfect, but I couldn't figure out why the the footer display refused to change to None on props change
- Added a classname specifically for the Logo to target it for CSS purposes