### PR TITLE
Update Modal.tsx

### DIFF
--- a/src/components/ModalPayment/Modal.tsx
+++ b/src/components/ModalPayment/Modal.tsx
@@ -109,12 +109,15 @@ const ModalContainer = styled.div`
   top: 0;
   left: 0;
   z-index: 10;
-  padding-bottom: 40px;
   width: 100%;
   height: 100%;
+  padding-bottom: 40px;
+  @media min-width: 1000px {
+    padding-bottom: 0;
+  }
 `;
 const ViewContainer = styled.div`
-  overflow-y: scroll;
+  overflow-y: auto;
   margin: 0 auto;
   height: 100%;
   width: 100%;
@@ -127,11 +130,16 @@ const CloseButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   width: 100%;
+  padding: 0;
+  @media min-width: 1000px {
+    padding: 0 50px;
+  }
 `;
 const CloseButton = styled.button`
-  width: 40px;
-  font-weight: bold;
-  font-size: 30px;
+  width: 45px;
+  font-weight: 500;
+  font-size: 45px;
+  line-height: 1;
   border: none;
   outline: none;
   cursor: pointer;


### PR DESCRIPTION
## [Ticket](https://trello.com/c/FCKwIKd7/782-checkout-modals-make-x-that-closes-the-modal-bigger)

### [Description of changes]
Increase the effective size of close button text by 1.5.

Evened out margins for tablet and mobile.

Updated vertical scrollbar to be visible only if the content exceeds the height of modal instead of always visible.

### [Screenshots or clip of change]
![screenshot-desktop](https://user-images.githubusercontent.com/82724041/115253887-d45c0280-a0fa-11eb-84a4-ac5f2f95df5e.png)
![screenshot2-tablet](https://user-images.githubusercontent.com/82724041/115253876-d1f9a880-a0fa-11eb-8ade-5132511c79b7.png)
![screenshot3-phone](https://user-images.githubusercontent.com/82724041/115253880-d32ad580-a0fa-11eb-98fa-5b048a90cb48.png)

### [Miscellaneous - e.g. special deployment procedure, testing, etc]
From navigation, click Ways to Donate > Gift a Meal and open the modal via Gift Meal CTA button below the main banner.