### PR TITLE
fix: navbar open menu no longer broken for some iPhone users

### DIFF
--- a/src/components/Navbar/NavBar.tsx
+++ b/src/components/Navbar/NavBar.tsx
@@ -9,6 +9,8 @@ import { Logo } from '../Logos';
 import { Page } from '../../consts';
 import { smallScreens } from '../../utilities/general/responsive';
 
+import styles from './styles.module.scss';
+
 interface Props {
   menuOpen: boolean;
   setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -145,7 +147,10 @@ const NavBar = (props: Props) => {
     );
   };
   return (
-    <HeaderContainer compact={hamburgerOpen.toString()}>
+    <HeaderContainer
+      compact={hamburgerOpen.toString()}
+      className={props.menuOpen ? '' : styles.sticky}
+    >
       <a className="nav-bar-logo" href="https://sendchinatownlove.com/">
         <Logo />
       </a>
@@ -232,8 +237,6 @@ const HeaderContainer = styled.header`
       margin-left: 19px;
     }
 
-    position: sticky;
-    position: -webkit-sticky;
     top: 0;
     z-index: ${theme.maxzIndex};
     background-color: white;
@@ -251,6 +254,7 @@ const NavLinksContainer = styled.div`
     props.compact === 'true' ? `column` : 'row'};
   width: 100%;
   position: relative;
+
   ${(props: CompactProps) =>
     props.compact === 'true'
       ? `

--- a/src/components/Navbar/styles.module.scss
+++ b/src/components/Navbar/styles.module.scss
@@ -1,0 +1,7 @@
+.sticky {
+  position: -webkit-sticky;
+  position: -moz-sticky;
+  position: -o-sticky;
+  position: -ms-sticky;
+  position: sticky;
+}


### PR DESCRIPTION
## [Fixing sticky navbar iOS bug](https://trello.com/c/pt5EGq1I/838-bugfix-for-sticky-navbar-on-ios)

### [Description of changes]
- conditionally applying sticky logic only when the menu is closed

### [Screenshots or clip of change]
<img width="324" alt="Screen Shot 2021-05-05 at 7 41 42 PM" src="https://user-images.githubusercontent.com/2818246/117222707-1a42e700-adda-11eb-83b1-b46155defb49.png">

### [Miscellaneous - e.g. special deployment procedure, testing, etc]
- tested on an iPhone SE v1 on iOS 14.3

### Other notes
- I think all our conditionality in the inline `styled` CSS is working... we should look into it and fix sometime