### PR TITLE
fixing purchase flow to prevent double clicking

### DIFF
--- a/src/components/ModalPayment/Modal.tsx
+++ b/src/components/ModalPayment/Modal.tsx
@@ -39,10 +39,10 @@ export const Modal = (props: Props) => {
   const dispatch = useModalPaymentDispatch(null);
 
   useEffect(() => {
-    const referrer = query.get("referrer") ? query.get("referrer") : null;
+    const referrer = query.get('referrer') ? query.get('referrer') : null;
     dispatch({ type: ModalPaymentConstants.SET_REFERRER, payload: referrer });
 
-  // eslint-disable-next-line
+    // eslint-disable-next-line
   }, []);
 
   useEffect(() => {

--- a/src/components/ModalPayment/ModalCardDetails/ModalCardDetails.tsx
+++ b/src/components/ModalPayment/ModalCardDetails/ModalCardDetails.tsx
@@ -60,7 +60,7 @@ const ModalCardDetails = ({
     lucData,
     matchAmount,
     campaignState,
-    referrer
+    referrer,
   } = useModalPaymentState(null);
   const dispatch = useModalPaymentDispatch(null);
   const modalRef = useScrollToElement();
@@ -71,6 +71,8 @@ const ModalCardDetails = ({
   const [email, setEmail] = useState('');
   const [errorMessages, setErrorsMessages] = useState<string[]>([]);
   const [canSubmit, setCanSubmit] = useState(false);
+  const [loading, setLoading] = useState(false);
+
   const isMegaGam: boolean =
     purchaseType === ModalPaymentTypes.modalPages.mega_gam;
 
@@ -181,7 +183,7 @@ const ModalCardDetails = ({
     };
 
     setCanSubmit(false);
-
+    setLoading(true);
     let metadata: any = {};
     if (projectId) metadata = lucData;
     if (referrer) metadata.referrer = referrer;
@@ -197,6 +199,8 @@ const ModalCardDetails = ({
       metadata !== {} ? JSON.stringify(metadata) : null
     )
       .then((res) => {
+        setCanSubmit(true);
+        setLoading(false);
         if (res.status === 200) {
           dispatch({
             type: ModalPaymentConstants.SET_MODAL_VIEW,
@@ -205,6 +209,8 @@ const ModalCardDetails = ({
         }
       })
       .catch((err) => {
+        setCanSubmit(true);
+        setLoading(false);
         if (err.response) {
           let responseErrors: ErrorMessage[] = [];
           if (err.response.data.errors)
@@ -498,7 +504,7 @@ const ModalCardDetails = ({
               >
                 ᐸ Back
               </BackButton>
-              <SubmissionButton canSubmit={canSubmit} />
+              <SubmissionButton canSubmit={canSubmit} loading={loading} />
             </ButtonRow>
           </SquarePaymentForm>
         </SquareFormContainer>

--- a/src/components/ModalPayment/ModalCardDetails/SubmissionButton.tsx
+++ b/src/components/ModalPayment/ModalCardDetails/SubmissionButton.tsx
@@ -1,14 +1,15 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext } from 'react';
 import { Context } from 'react-square-payment-form';
 import ReactPixel from 'react-facebook-pixel';
+import Loader from '../../Loader';
 
 type Props = {
   canSubmit: boolean;
+  loading: boolean;
 };
 
-const SubmissionButton = ({ canSubmit }: Props) => {
+const SubmissionButton = ({ canSubmit, loading }: Props) => {
   const context = useContext(Context);
-  var [submittable] = useState(false);
 
   const handleSubmit = (evt: { preventDefault: () => void }) => {
     ReactPixel.trackCustom('PaymentConfirmButtonClick', {});
@@ -16,16 +17,14 @@ const SubmissionButton = ({ canSubmit }: Props) => {
     context.onCreateNonce();
   };
 
-  submittable = canSubmit;
-
   return (
     <button
       type="button"
       className={'modalButton--filled'}
       onClick={handleSubmit}
-      disabled={!submittable}
+      disabled={!canSubmit || loading}
     >
-      Confirm
+      {loading ? <Loader size="20px" color="white" /> : 'Confirm'}
     </button>
   );
 };


### PR DESCRIPTION
adding loading animation for payment button when interacting with square api when authorizing payment

## [Ticket](insert_trello_card_link_here)
https://trello.com/c/PGyHxwIB/837-high-priority-fix-purchase-flow-to-prevent-double-clicking
### [Description of changes]
added loading animation and loading toggling whena nonce is being made and being created
### [Screenshots or clip of change]

### [Miscellaneous - e.g. special deployment procedure, testing, etc]
