### PR TITLE
make faster by caching results so its not refreshed between merchant …

### DIFF
--- a/src/utilities/api/interactionManager.ts
+++ b/src/utilities/api/interactionManager.ts
@@ -32,15 +32,19 @@ import {
 // Fix return typing
 
 let CACHE = {};
+const cache_duration = 300; // 5 minutes expressed in seconds
+let expiration_time = ~~(Date.now() / 1000); // time in seconds
 
 export const getSellers = async (lang?: string): Promise<any> => {
-  if (Object.entries(CACHE).length !== 0) {
+  const current_time = ~~(Date.now() / 1000);
+  if (Object.entries(CACHE).length !== 0 && expiration_time > current_time) {
     return CACHE;
   }
   const result = await axios.get(sellers, {
     params: { locale: localeFromLanguage(lang) },
   });
   CACHE = result;
+  expiration_time = current_time + cache_duration;
   return CACHE;
 };
 

--- a/src/utilities/api/interactionManager.ts
+++ b/src/utilities/api/interactionManager.ts
@@ -30,10 +30,18 @@ import {
 } from './endpoints';
 
 // Fix return typing
+
+let CACHE = {};
+
 export const getSellers = async (lang?: string): Promise<any> => {
-  return await axios.get(sellers, {
+  if (Object.entries(CACHE).length !== 0) {
+    return CACHE;
+  }
+  const result = await axios.get(sellers, {
     params: { locale: localeFromLanguage(lang) },
   });
+  CACHE = result;
+  return CACHE;
 };
 
 export const getSeller = async (id: string, lang?: string): Promise<any> => {


### PR DESCRIPTION
…navigation trello #842

## [Ticket](https://trello.com/c/9TIXj0Gk/842-use-local-cache-so-only-one-network-call-is-made-when-a-user-navigates-between-merchants-on-the-merchant-page)

### [Description of changes]

make even faster by persisting network results between navigation 

### [Screenshots or clip of change]

### [Miscellaneous - e.g. special deployment procedure, testing, etc]
